### PR TITLE
XSD based cius-extension-xml model

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,6 @@ This repo contains draft of machine readable format for describing CIUS and exte
 * `xslt` -- auxiliary transformations
   `config2html.xsl` -- XSLT transformation that can render any XML configuration file into HTML
 
-* `schema` -- schama for configuration files 
+* `schema` -- schema for CIUS and Extension configuration files 
 
 If you find some bug or there is something missing please file a new issue https://github.com/CenPC434/ce-config/issues
-
-
-

--- a/README.md
+++ b/README.md
@@ -93,6 +93,6 @@ and guaranty compliance:
 An example showing all possible changes which are are allowed according to CEN
 16931-1:2017 with fictive date is given in this [XML Instance](./examples/example-cius.xml).
 
-A real CIUS is the [German CIUS XRechnung]([XML Instance](./examples/example-de-cius.xml).) 
+A real CIUS is the [German CIUS XRechnung]([XML Instance](./examples/example-de-cius.xml). 
 
     

--- a/README.md
+++ b/README.md
@@ -93,6 +93,6 @@ and guaranty compliance:
 An example showing all possible changes which are are allowed according to CEN
 16931-1:2017 with fictive date is given in this [XML Instance](./examples/example-cius.xml).
 
-A real CIUS is the [German CIUS XRechnung]([XML Instance](./examples/example-de-cius.xml). 
+A real CIUS is the [German CIUS XRechnung](./examples/example-de-cius.xml). 
 
     

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ and guaranty compliance:
   * Remove one of multiple defined lists
   * Mark defined values as not allowed   
 * **Business rules**
-  * Add new non-conflicting business for existing element(s)
+  * Add new non-conflicting business rule for existing element(s)
   * Make an existing business rule more restrictive
 * **Value domain for an information element**
   * Restrict text or byte array length

--- a/README.md
+++ b/README.md
@@ -1,16 +1,98 @@
-# CIUS and Extension configuration format for EU invoice
+# CIUS and Extension description format for EU electronic invoicing
 
-This repo contains draft of machine readable format for describing CIUS and extensions of EU invoice (EN 16931-1:2017)
+This repository contains a machine readable XML format for describing Core
+Invoice Usage Specifications (CIUS) and extensions fully compliant to the
+methodology and rules of EU electronic invoicing
+(EN 16931-1:2017)
 
 * `examples/` -- folder with sample data
 
   `*.xml` -- sample configuration files
-
-  `*.html` -- human readable rendering of configuration files
 
 * `xslt` -- auxiliary transformations
   `config2html.xsl` -- XSLT transformation that can render any XML configuration file into HTML
 
 * `schema` -- schema for CIUS and Extension configuration files 
 
-If you find some bug or there is something missing please file a new issue https://github.com/CenPC434/ce-config/issues
+If you find some bug or there is something missing please file a new issue.
+
+
+## Details
+
+First the compliance criteria and rules are given and second an
+example is given demonstrating that this CIUS and extension description format allows
+to specify a fully compliant CIUS in machine readable format.
+
+### Compliance
+
+The European Standard EN 16931-1:2017 "Electronic invoicing - Part 1: Semantic
+datamodel of the core elements of an electronic invoice" describes the Core
+Invoice Usage Specification (CIUS) as a means to comply to the core invoice
+model at the specification level (see 4.4. and 7.3).
+
+
+A CIUS has to meet the following criteria:
+
+* give a clear statement on the business function or legal requirements
+* give information on the publisher and governor
+* give a clear statement on the difference of the core invoice model either by 
+  * documenting the difference only
+  * documenting all and pointing out the differences
+* instances shall be fully compliant 
+* shall be uniquely identifiable and may include version information
+* shall give a clear statement about its underlying specifications 
+* shall follow the syntax binding methodology as defined in CEN/TS 16931-3-1:201
+
+A CIUS may specify how it creates usage guidelines and restrictions within the
+core invoice model.
+
+The following key elements of the core invoice model may be further restricted i.e. gain
+higher specificity:
+
+* **Business terms**: "A CIUS may reduce the list of conditional elements or further
+specify their definition"
+* **Cardinality**: "A CIUS may restrict this and consequently affect how the
+receiver shall or can process the invoice instance document."
+* **Semantic data type**: "Parties may want to further restrict the value domain of
+a semantic data type"
+* **Codes and identifiers**: "In order to support specific requiremetns the trading
+partners may need to chanfe these defintions."
+* **Business rules**: "Partner may need to change or add to these rules in order to
+meet specific business requirements."
+* **Value domain for an information element**: "Trading partners may want to
+prescribe such rules where there are none or to restrict existing ones to
+support specefic requirements."
+
+Hence the following changes in reference to the core invoice model are allowed
+and guaranty compliance:
+
+* **Business terms**:
+  * Mark conditional information element not to be used
+  * Make semantic definition narrower
+  * Add synonyms 
+  * Add explanatory text
+* **Cardinality**
+  * Make a conditional element mandatory
+  * Decrease number of repetitions
+* **Semantic data type**
+  * Change semantic data type from string to ...
+* **Codes and identifiers**
+  * Remove one of multiple defined lists
+  * Mark defined values as not allowed   
+* **Business rules**
+  * Add new non-conflicting business for existing element(s)
+  * Make an existing business rule more restrictive
+* **Value domain for an information element**
+  * Restrict text or byte array length
+  * Require defined structured values
+  * Restrict allowed fraction digits
+  
+  
+### Compliance Example
+
+An example showing all possible changes which are are allowed according to CEN
+16931-1:2017 with fictive date is given in this [XML Instance](./examples/example-cius.xml).
+
+A real CIUS is the [German CIUS XRechnung]([XML Instance](./examples/example-de-cius.xml).) 
+
+    

--- a/doc/CIUS Metadata and Data.md
+++ b/doc/CIUS Metadata and Data.md
@@ -1,0 +1,33 @@
+# Task: Definition of a language to describe CIUS in a machine processable format
+
+## Metadata
+
+Comparision of available sources describing / utilizing Metadata related to CIUS
+
+1. CEF Website
+1. CEN TC 434 Deliverable: CIUS Methodology
+1. Existing aproaches for machine readable CIUS from DE and AT
+
+
+|Semantic|CEF|CEN|DE/AT|
+|--|--|--|--|--|
+|Short name for general reference| Name| | | 
+|Long name ||||
+|Technical name / id||||
+|Version||||
+|Status|Status|||
+|Type|Type|||
+|Country|Country|||
+|Sector|Sector|||
+|Description of the intended application|Purpose of the CIUS or Extension|||
+|Governor|Governor|||
+|Publisher|Publisher|||
+|E-Mail contact to publisher||||
+|Underlying specification|Underlying specification|||
+|Link to information source|Further information|||
+
+
+
+
+## Data
+

--- a/doc/CIUS Metadata and Data.md
+++ b/doc/CIUS Metadata and Data.md
@@ -6,7 +6,7 @@ Comparision of available sources describing / utilizing Metadata related to CIUS
 
 1. CEF Website
 1. CEN TC 434 Deliverable: CIUS Methodology
-1. Existing aproaches for machine readable CIUS from DE and AT
+1. Existing approaches for machine readable CIUS from DE and AT
 
 
 |Semantic|CEF|CEN|DE/AT|

--- a/examples/example-cius.xml
+++ b/examples/example-cius.xml
@@ -92,7 +92,7 @@
 
   <!-- Now describing business rules of CIUS -->
   <business-rules>
-    <!-- Allowed change:  Add new non-conflicting business for existing element(s)-->
+    <!-- Allowed change:  Add new non-conflicting business rule for existing element(s)-->
     <rule id="BR-501" cius-specific="true">
       <description xml:lang="en">Add a new non-conflicting business rule. It is
         semantically more restrictive on business term BT-318 and only allows

--- a/examples/example-cius.xml
+++ b/examples/example-cius.xml
@@ -50,6 +50,7 @@
     <business-term id="BT-301" cius-specific="true" semantic-datatype="Amount">
       <usage-note xml:lang="en">Only a specefic narrow Amount between 1 and 2 is
         allowed</usage-note>
+      <cardinality minOccurs="1"/>
     </business-term>
 
     <!-- Allowed change: Add synonyms  -->

--- a/examples/example-cius.xml
+++ b/examples/example-cius.xml
@@ -109,7 +109,7 @@
 
     <!-- Allowed change: Make an existing business rule more restrictive  -->
     <rule id="BR-1" cius-specific="true">
-      <description xml:lang="en">Makes existing BR-1 rule more restrivtive by
+      <description xml:lang="en">Makes existing BR-1 rule more restrictive by
         restricting cardinality to maximum 1</description>
       <restrictions>
         <cardinality term="BT-301" minOccurs="1" maxOccurs="1"/>

--- a/examples/example-cius.xml
+++ b/examples/example-cius.xml
@@ -40,18 +40,19 @@
   <!-- Examples demonstrating ALL allowed changes in reference to core
     information model -->
   <information-elements>
-    <!-- id=BG-100 refers to a fictive BG-100 in core information model -->
-    <business-group id="BG-100" level="1" cius-specific="true">
-      <!-- Allowed change: Mark conditional information element not to be used  -->
-      <cardinality minOccurs="0" maxOccurs="0"/>
-    </business-group>
+    
+
+
+    <!-- Allowed change: Add explanatory text -->
+    <business-term id="BT-303" cius-specific="true">
+      <usage-note xml:lang="en">Very explanatory additonal text
+        here.</usage-note>
+    </business-term>
 
     <!-- Allowed change: Make semantic definition narrower -->
     <business-term id="BT-301" cius-specific="true" semantic-datatype="Amount">
-      <cardinality minOccurs="1"/>
       <usage-note xml:lang="en">Only a specefic narrow Amount between 1 and 2 is
         allowed</usage-note>
-      
     </business-term>
 
     <!-- Allowed change: Add synonyms  -->
@@ -61,11 +62,6 @@
       <synonym xml:lang="de">Yet another name for BT-2 in German language</synonym>
     </business-term>
 
-    <!-- Allowed change: Add explanatory text -->
-    <business-term id="BT-303" cius-specific="true">
-      <usage-note xml:lang="en">Very explanatory additonal text
-        here.</usage-note>
-    </business-term>
 
     <!-- Allowed change: Make a conditional element mandatory -->
     <business-term id="BT-304" cius-specific="true">
@@ -90,6 +86,14 @@
         <allowed-codes>1 2 3 4</allowed-codes>
       </codelist-values>
     </business-term>
+    
+    <!-- id=BG-100 refers to a fictive BG-100 in core information model -->
+    <!-- evtl. erstmal rausnehmen, obwohl NORM zulaesst Regeln auf GB Ebene yu
+      definieren -->
+    <business-group id="BG-100" level="1" cius-specific="true">
+      <!-- Allowed change: Mark conditional information element not to be used  -->
+      <cardinality minOccurs="0" maxOccurs="0"/>
+    </business-group>
   </information-elements>
 
   <!-- Now describing business rules of CIUS -->
@@ -100,10 +104,10 @@
         semantically more restrictive on business term BT-318 and only allows
         values 1 2 3 4 from codelist-2</description>
       <restrictions>
-        <codelist name="codelist-2">
+        <codelist name="codelist-2" term="BT-10">
           <allowed-codes>1 2 3 4</allowed-codes>
         </codelist>
-        <semantic-definition>
+        <semantic-definition term="BT-10">
           <term>BT-318</term>
         </semantic-definition>
       </restrictions>
@@ -122,16 +126,16 @@
     <rule id="BR-XX-502" cius-specific="true">
       <description xml:lang="en">restricting length</description>
       <restrictions>
-        <value-domain length="10"/>
+        <value-domain length="10" term="BT-10"/>
       </restrictions>
     </rule>
 
     <!-- Allowed change: Require defined structured values -->
-    <rule id="BR-XX-503" cius-specific="true" core-elements="BT-10">
+    <rule id="BR-XX-503" cius-specific="true">
       <description xml:lang="en">Give a format description which is more
         restrictive on BT-10</description>
       <restrictions>
-        <value-domain format="10s%"/>
+        <value-domain format="10s%" term="BT-10"/>
       </restrictions>
     </rule>
 
@@ -139,7 +143,7 @@
     <rule id="BR-XX-504" cius-specific="true">
       <description xml:lang="en">Just being rigid</description>
       <restrictions>
-        <value-domain fraction-digit="1"/>
+        <value-domain fraction-digit="1" term="BT-10"/>
       </restrictions>
     </rule>
   </business-rules>

--- a/examples/example-cius.xml
+++ b/examples/example-cius.xml
@@ -48,9 +48,10 @@
 
     <!-- Allowed change: Make semantic definition narrower -->
     <business-term id="BT-301" cius-specific="true" semantic-datatype="Amount">
+      <cardinality minOccurs="1"/>
       <usage-note xml:lang="en">Only a specefic narrow Amount between 1 and 2 is
         allowed</usage-note>
-      <cardinality minOccurs="1"/>
+      
     </business-term>
 
     <!-- Allowed change: Add synonyms  -->
@@ -94,7 +95,7 @@
   <!-- Now describing business rules of CIUS -->
   <business-rules>
     <!-- Allowed change:  Add new non-conflicting business rule for existing element(s)-->
-    <rule id="BR-501" cius-specific="true">
+    <rule id="BR-XX-500" cius-specific="true">
       <description xml:lang="en">Add a new non-conflicting business rule. It is
         semantically more restrictive on business term BT-318 and only allows
         values 1 2 3 4 from codelist-2</description>
@@ -109,7 +110,7 @@
     </rule>
 
     <!-- Allowed change: Make an existing business rule more restrictive  -->
-    <rule id="BR-1" cius-specific="true">
+    <rule id="BR-XX-501" cius-specific="true">
       <description xml:lang="en">Makes existing BR-1 rule more restrictive by
         restricting cardinality to maximum 1</description>
       <restrictions>
@@ -118,7 +119,7 @@
     </rule>
 
     <!-- Allowed change: Restrict text or byte array length -->
-    <rule id="BR-502" cius-specific="true">
+    <rule id="BR-XX-502" cius-specific="true">
       <description xml:lang="en">restricting length</description>
       <restrictions>
         <value-domain length="10"/>
@@ -126,7 +127,7 @@
     </rule>
 
     <!-- Allowed change: Require defined structured values -->
-    <rule id="BR-503" cius-specific="true" core-elements="BT-10">
+    <rule id="BR-XX-503" cius-specific="true" core-elements="BT-10">
       <description xml:lang="en">Give a format description which is more
         restrictive on BT-10</description>
       <restrictions>
@@ -135,7 +136,7 @@
     </rule>
 
     <!-- Allowed change: Restrict allowed fraction digits -->
-    <rule id="BR-504" cius-specific="true">
+    <rule id="BR-XX-504" cius-specific="true">
       <description xml:lang="en">Just being rigid</description>
       <restrictions>
         <value-domain fraction-digit="1"/>

--- a/examples/example-cius.xml
+++ b/examples/example-cius.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?xml-model href="../schema/ce-config.xsd"?>
+<!-- This is an example CIUS with fictive examples not reflecting any real
+  content. The sole purpose is too demonstrate the features of this XML
+  structure -->
+<!-- Fulfils criterium: instances shall be fully compliant see README.md for
+  more details -->
+<cius xmlns="urn:x-namespace:yet:to:be:determined">
+  <metadata>
+    <nameShort>cius demonstration</nameShort>
+    <nameLong>A demonstration of how to define a CIUS using this XML structure</nameLong>
+    <!-- Fulfils criterium: shall be uniquely identifiable and may include version information -->
+    <nameTechnical>cius:demonstrandum</nameTechnical>
+    <!-- Fulfils criterium: shall give a clear statement about its underlying specifications -->
+    <underlyingSpecification>EN16931-1:2017</underlyingSpecification>
+    <!-- Fulfils criterium: shall be uniquely identifiable and may include version information -->
+    <version>0.3</version>
+    <status>development</status>
+    <date>2018-10-02</date>
+    <!-- Fullfils criterium: give information on the publisher and governor -->
+    <publisher>KoSIT</publisher>
+    <!-- Fullfils criterium: give information on the publisher and governor -->
+    <governor>all</governor>
+    <contact>renzo.kottmann@finanzen.bremen.de</contact>
+    <abstract xml:lang="en">This document serves the purpose to demonstrate how
+      a EN16931-1:2017 compliant description of a CIUS is made possible by this
+      XML structure as defined by an XSD</abstract>
+    <furtherInformation>https://github.com/itplr-kosit/ce-config/blob/cius-rule-and-bt-model/schema/ce-config.xsd</furtherInformation>
+  </metadata>
+
+  <!-- Fulfils criterium: give a clear statement on the business function or legal requirements -->
+  <description xml:lang="en">The function of this CIUS demonstration instance is
+    to describe how it fulfils all criteria, requirements and rules on defining
+    an EN16931-1:2017 compliant CIUS. In addition "A CIUS may specify how it
+    creates usage guidelines and restrictions within the core invoice model."
+    All CIUSs can use this description on general usage guidelines. Restrictions
+    within the core invoice model can be specified in "infomation-elements"
+    section. </description>
+  <!-- Examples demonstrating ALL allowed changes in reference to core
+    information model -->
+  <information-elements>
+    <!-- id=BG-100 refers to a fictive BG-100 in core information model -->
+    <business-group id="BG-100" level="1" cius-specific="true">
+      <!-- Allowed change: Mark conditional information element not to be used  -->
+      <cardinality minOccurs="0" maxOccurs="0"/>
+    </business-group>
+
+    <!-- Allowed change: Make semantic definition narrower -->
+    <business-term id="BT-301" cius-specific="true" semantic-datatype="Amount">
+      <usage-note xml:lang="en">Only a specefic narrow Amount between 1 and 2 is
+        allowed</usage-note>
+    </business-term>
+
+    <!-- Allowed change: Add synonyms  -->
+    <business-term id="BT-302" cius-specific="true">
+      <!-- Many synonyms are possible -->
+      <synonym xml:lang="en">Another name for BT-2</synonym>
+      <synonym xml:lang="de">Yet another name for BT-2 in German language</synonym>
+    </business-term>
+
+    <!-- Allowed change: Add explanatory text -->
+    <business-term id="BT-303" cius-specific="true">
+      <usage-note xml:lang="en">Very explanatory additonal text
+        here.</usage-note>
+    </business-term>
+
+    <!-- Allowed change: Make a conditional element mandatory -->
+    <business-term id="BT-304" cius-specific="true">
+      <cardinality minOccurs="1"/>
+    </business-term>
+
+    <!-- Allowed change: Decrease number of repetitions -->
+    <business-term id="BT-305" cius-specific="true">
+      <cardinality maxOccurs="5"/>
+    </business-term>
+
+    <!-- Allowed change: Change semantic data type from string to  -->
+    <business-term id="BT-306" cius-specific="true" semantic-datatype="Binary"/>
+
+    <!-- Allowed change: Remove one of multiple defined lists -->
+    <business-term id="BT-307" cius-specific="true">
+      <codelist-restriction listName="codelist1" removed="true"/>
+    </business-term>
+    <!-- Allowed change: Mark defined values as not allowed  -->
+    <business-term id="BT-308" cius-specific="true">
+      <codelist-values>
+        <allowed-codes>1 2 3 4</allowed-codes>
+      </codelist-values>
+    </business-term>
+  </information-elements>
+
+  <!-- Now describing business rules of CIUS -->
+  <business-rules>
+    <!-- Allowed change:  Add new non-conflicting business for existing element(s)-->
+    <rule id="BR-501" cius-specific="true">
+      <description xml:lang="en">Add a new non-conflicting business rule. It is
+        semantically more restrictive on business term BT-318 and only allows
+        values 1 2 3 4 from codelist-2</description>
+      <restrictions>
+        <codelist name="codelist-2">
+          <allowed-codes>1 2 3 4</allowed-codes>
+        </codelist>
+        <semantic-definition>
+          <term>BT-318</term>
+        </semantic-definition>
+      </restrictions>
+    </rule>
+
+    <!-- Allowed change: Make an existing business rule more restrictive  -->
+    <rule id="BR-1" cius-specific="true">
+      <description xml:lang="en">Makes existing BR-1 rule more restrivtive by
+        restricting cardinality to maximum 1</description>
+      <restrictions>
+        <cardinality term="BT-301" minOccurs="1" maxOccurs="1"/>
+      </restrictions>
+    </rule>
+
+    <!-- Allowed change: Restrict text or byte array length -->
+    <rule id="BR-502" cius-specific="true">
+      <description xml:lang="en">restricting length</description>
+      <restrictions>
+        <value-domain length="10"/>
+      </restrictions>
+    </rule>
+
+    <!-- Allowed change: Require defined structured values -->
+    <rule id="BR-503" cius-specific="true" core-elements="BT-10">
+      <description xml:lang="en">Give a format description which is more
+        restrictive on BT-10</description>
+      <restrictions>
+        <value-domain format="10s%"/>
+      </restrictions>
+    </rule>
+
+    <!-- Allowed change: Restrict allowed fraction digits -->
+    <rule id="BR-504" cius-specific="true">
+      <description xml:lang="en">Just being rigid</description>
+      <restrictions>
+        <value-domain fraction-digit="1"/>
+      </restrictions>
+    </rule>
+  </business-rules>
+</cius>

--- a/examples/example-cius.xml
+++ b/examples/example-cius.xml
@@ -6,7 +6,7 @@
   structure -->
 <!-- Fulfils criterium: instances shall be fully compliant see README.md for
   more details -->
-<cius xmlns="urn:x-namespace:yet:to:be:determined">
+<cius xmlns="urn:x-namespace:yet:to:be:determined" type="restriction">
   <metadata>
     <nameShort>cius demonstration</nameShort>
     <nameLong>A demonstration of how to define a CIUS using this XML structure</nameLong>
@@ -39,67 +39,34 @@
     section. </description>
   <!-- Examples demonstrating ALL allowed changes in reference to core
     information model -->
+  
+  <!-- This section is optional and is e.g. motivated by being able to represent
+  the NORM itself in future-->
   <information-elements>
-    
-
-
     <!-- Allowed change: Add explanatory text -->
-    <business-term id="BT-303" cius-specific="true">
+    <business-term id="BT-303" >
       <usage-note xml:lang="en">Very explanatory additonal text
         here.</usage-note>
     </business-term>
 
     <!-- Allowed change: Make semantic definition narrower -->
-    <business-term id="BT-301" cius-specific="true" semantic-datatype="Amount">
+    <business-term id="BT-301"  semantic-datatype="Amount"> 
       <usage-note xml:lang="en">Only a specefic narrow Amount between 1 and 2 is
         allowed</usage-note>
     </business-term>
 
     <!-- Allowed change: Add synonyms  -->
-    <business-term id="BT-302" cius-specific="true">
+    <business-term id="BT-302" >
       <!-- Many synonyms are possible -->
       <synonym xml:lang="en">Another name for BT-2</synonym>
       <synonym xml:lang="de">Yet another name for BT-2 in German language</synonym>
     </business-term>
-
-
-    <!-- Allowed change: Make a conditional element mandatory -->
-    <business-term id="BT-304" cius-specific="true">
-      <cardinality minOccurs="1"/>
-    </business-term>
-
-    <!-- Allowed change: Decrease number of repetitions -->
-    <business-term id="BT-305" cius-specific="true">
-      <cardinality maxOccurs="5"/>
-    </business-term>
-
-    <!-- Allowed change: Change semantic data type from string to  -->
-    <business-term id="BT-306" cius-specific="true" semantic-datatype="Binary"/>
-
-    <!-- Allowed change: Remove one of multiple defined lists -->
-    <business-term id="BT-307" cius-specific="true">
-      <codelist-restriction listName="codelist1" removed="true"/>
-    </business-term>
-    <!-- Allowed change: Mark defined values as not allowed  -->
-    <business-term id="BT-308" cius-specific="true">
-      <codelist-values>
-        <allowed-codes>1 2 3 4</allowed-codes>
-      </codelist-values>
-    </business-term>
-    
-    <!-- id=BG-100 refers to a fictive BG-100 in core information model -->
-    <!-- evtl. erstmal rausnehmen, obwohl NORM zulaesst Regeln auf GB Ebene yu
-      definieren -->
-    <business-group id="BG-100" level="1" cius-specific="true">
-      <!-- Allowed change: Mark conditional information element not to be used  -->
-      <cardinality minOccurs="0" maxOccurs="0"/>
-    </business-group>
   </information-elements>
 
   <!-- Now describing business rules of CIUS -->
   <business-rules>
     <!-- Allowed change:  Add new non-conflicting business rule for existing element(s)-->
-    <rule id="BR-XX-500" cius-specific="true">
+    <rule id="BR-XX-500" >
       <description xml:lang="en">Add a new non-conflicting business rule. It is
         semantically more restrictive on business term BT-318 and only allows
         values 1 2 3 4 from codelist-2</description>
@@ -107,23 +74,25 @@
         <codelist name="codelist-2" term="BT-10">
           <allowed-codes>1 2 3 4</allowed-codes>
         </codelist>
-        <semantic-definition term="BT-10">
+        <semantic-definition>
           <term>BT-318</term>
+          <term>BT-518</term> 
         </semantic-definition>
       </restrictions>
     </rule>
 
     <!-- Allowed change: Make an existing business rule more restrictive  -->
-    <rule id="BR-XX-501" cius-specific="true">
+    <rule id="BR-XX-501">
       <description xml:lang="en">Makes existing BR-1 rule more restrictive by
         restricting cardinality to maximum 1</description>
       <restrictions>
-        <cardinality term="BT-301" minOccurs="1" maxOccurs="1"/>
+        <cardinality term="BT-301 BT-444" minOccurs="1" maxOccurs="1"/>
+
       </restrictions>
     </rule>
 
     <!-- Allowed change: Restrict text or byte array length -->
-    <rule id="BR-XX-502" cius-specific="true">
+    <rule id="BR-XX-502" >
       <description xml:lang="en">restricting length</description>
       <restrictions>
         <value-domain length="10" term="BT-10"/>
@@ -131,7 +100,7 @@
     </rule>
 
     <!-- Allowed change: Require defined structured values -->
-    <rule id="BR-XX-503" cius-specific="true">
+    <rule id="BR-XX-503" >
       <description xml:lang="en">Give a format description which is more
         restrictive on BT-10</description>
       <restrictions>
@@ -140,7 +109,7 @@
     </rule>
 
     <!-- Allowed change: Restrict allowed fraction digits -->
-    <rule id="BR-XX-504" cius-specific="true">
+    <rule id="BR-XX-504" >
       <description xml:lang="en">Just being rigid</description>
       <restrictions>
         <value-domain fraction-digit="1" term="BT-10"/>

--- a/examples/example-de-cius.xml
+++ b/examples/example-de-cius.xml
@@ -10,9 +10,9 @@
 
   This example uses prevoius work of AT National CIUS provided by Philip Helger
  
-  -->
+  --> 
 <?xml-model href="../schema/ce-config.xsd"?>
-<c:cius xmlns:c="urn:x-namespace:yet:to:be:determined"
+<c:cius type="restriction" xmlns:c="urn:x-namespace:yet:to:be:determined"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns:html="http://www.w3.org/1999/xhtml">
 
@@ -72,7 +72,7 @@
 
   <!-- The following set of rules are a technical representation of the set of rules given by the German CIUS XRechnung-->
   <c:business-rules>
-    <c:rule id="BR-DE-1" cius-specific="true">
+    <c:rule id="BR-DE-1" >
       <c:description xml:lang="de">Eine Rechnung (INVOICE) muss Angaben zu
         „PAYMENT INSTRUCTIONS“ (BG-16) enthalten.</c:description>
       <c:description xml:lang="en">The INVOICE shall contain information on
@@ -83,7 +83,7 @@
       </c:restrictions>
     </c:rule>
 
-    <c:rule id="BR-DE-2" cius-specific="true">
+    <c:rule id="BR-DE-2" >
       <c:description xml:lang="en">Die Gruppe „SELLER CONTACT“ (BG-6) muss
         übermittelt werden.</c:description>
       <c:description xml:lang="en">The group SELLER CONTACT1 (BG-6) shall be
@@ -93,7 +93,7 @@
       </c:restrictions>
     </c:rule>
 
-    <c:rule id="BR-DE-3" cius-specific="true">
+    <c:rule id="BR-DE-3" >
       <c:description xml:lang="de">Das Element „Seller city“ (BT-37) muss
         übermittelt werden.</c:description>
       <c:description xml:lang="en">The element “Seller city” (BT-37) shall be
@@ -104,7 +104,7 @@
 
     </c:rule>
 
-    <c:rule id="BR-DE-4" cius-specific="true">
+    <c:rule id="BR-DE-4" >
       <c:description xml:lang="de">Das Element „Seller post code“ (BT-38) muss
         übermittelt werden.</c:description>
       <c:description xml:lang="en">The element “Seller post code” (BT-38) shall
@@ -114,7 +114,7 @@
       </c:restrictions>
     </c:rule>
 
-    <c:rule id="BR-DE-5" cius-specific="true">
+    <c:rule id="BR-DE-5" >
       <c:description xml:lang="de">Das Element „Seller contact point“ (BT-41)
         muss übermittelt werden.</c:description>
       <c:description xml:lang="en">The element “Seller contact point” (BT-41)
@@ -124,7 +124,7 @@
       </c:restrictions>
     </c:rule>
 
-    <c:rule id="BR-DE-6" cius-specific="true">
+    <c:rule id="BR-DE-6" >
       <c:description xml:lang="de">Das Element „Seller contact telephone number“
         (BT-42) muss übermittelt werden.</c:description>
       <c:description xml:lang="en">The element „Seller contact telephone
@@ -134,7 +134,7 @@
       </c:restrictions>
     </c:rule>
 
-    <c:rule id="BR-DE-7" cius-specific="true">
+    <c:rule id="BR-DE-7" >
       <c:description xml:lang="de">Das Element „Seller contact email address“
         (BT-43) muss übermittelt werden.</c:description>
       <c:description xml:lang="en">The element “Seller contact email address”
@@ -144,7 +144,7 @@
       </c:restrictions>
     </c:rule>
 
-    <c:rule id="BR-DE-8" cius-specific="true">
+    <c:rule id="BR-DE-8" >
       <c:description xml:lang="de">Das Element „Buyer city“ (BT-52) muss
         übermittelt werden.</c:description>
       <c:description xml:lang="en">The element “Buyer city” (BT-52) shall be
@@ -154,7 +154,7 @@
       </c:restrictions>
     </c:rule>
 
-    <c:rule id="BR-DE-9" cius-specific="true">
+    <c:rule id="BR-DE-9" >
       <c:description xml:lang="de">Das Element „Buyer post code“ (BT-53) muss
         übermittelt werden.</c:description>
       <c:description xml:lang="en">The element “Buyer post code” (BT-53) shall
@@ -164,7 +164,7 @@
       </c:restrictions>
     </c:rule>
 
-    <c:rule id="BR-DE-10" cius-specific="true">
+    <c:rule id="BR-DE-10" >
       <c:description xml:lang="de">Das Element „Deliver to city“ (BT-77) muss
         übermittelt werden.</c:description>
       <c:description xml:lang="en">The element “Deliver to city“” (BT-77) shall
@@ -174,7 +174,7 @@
       </c:restrictions>
     </c:rule>
 
-    <c:rule id="BR-DE-11" cius-specific="true">
+    <c:rule id="BR-DE-11" >
       <c:description xml:lang="de">Das Element „Deliver to post code“ (BT-78)
         muss übermittelt werden.</c:description>
       <c:description xml:lang="en">The element “Deliver to post code” (BT-78)
@@ -185,7 +185,7 @@
       </c:restrictions>
     </c:rule>
 
-    <c:rule id="BR-DE-12" cius-specific="true">
+    <c:rule id="BR-DE-12" >
       <c:description xml:lang="de">Mit dem Element „Deliver to post code“
         (BT-78) muss eine Postleitzahl übermittelt werden.</c:description>
       <c:description xml:lang="en">A post code shall be transmitted together
@@ -195,7 +195,7 @@
       </c:restrictions>
     </c:rule>
 
-    <c:rule id="BR-DE-13" cius-specific="true">
+    <c:rule id="BR-DE-13" >
       <c:description xml:lang="de">In der Rechnung müssen Angaben zu einer der
         drei Gruppen „CREDIT TRANSFER“ (BG-17), „PAYMENT CARD INFORMATION“
         (BG-18) oder „DIRECT DEBIT“ (BG-19) übermittelt werden.</c:description>
@@ -215,7 +215,7 @@
 
     </c:rule>
 
-    <c:rule id="BR-DE-14" cius-specific="true">
+    <c:rule id="BR-DE-14" >
       <c:description xml:lang="de">Das Element „VAT category rate“ (BT-119) muss
         übermittelt werden.</c:description>
       <c:description xml:lang="en">The element “VAT category rate” (BT-119)
@@ -225,7 +225,7 @@
       </c:restrictions>
     </c:rule>
 
-    <c:rule id="BR-DE-15" cius-specific="true">
+    <c:rule id="BR-DE-15" >
       <c:description xml:lang="de">Das Element „Buyer reference“ (BT-10) muss
         übermittelt werden.</c:description>
       <c:description xml:lang="en">The element „Buyer reference“ (BT-10) shall
@@ -235,7 +235,7 @@
       </c:restrictions>
     </c:rule>
 
-    <c:rule id="BR-DE-16" cius-specific="true">
+    <c:rule id="BR-DE-16" >
       <c:description xml:lang="de">Das Element „Seller VAT identifier“ (BT-31)
         muss übermittelt werden, wenn nicht das Element „Seller tax registration
         identifier“ (BT-32) oder eine Gruppe „SELLER TAX REPRESENTATIVE PARTY“
@@ -255,7 +255,7 @@
       </c:restrictions>
     </c:rule>
 
-    <c:rule id="BR-DE-17"  cius-specific="true">
+    <c:rule id="BR-DE-17"  >
       <c:description xml:lang="de">Mit dem Element „Invoice type code“ (BT-3)
         sollen ausschließlich folgende Codes aus der Codeliste UNTDID 1001
         übermittelt werden: 326 (Partial invoice), 380 (Commercial invoice), 384
@@ -271,7 +271,7 @@
       </c:restrictions>
     </c:rule>
 
-    <c:rule id="BR-DE-18" cius-specific="true">
+    <c:rule id="BR-DE-18" >
       <c:description xml:lang="de">Informationen zur Gewährung von Skonto oder
         zur Berechnung von Verzugszinsen müssen wie folgt im Element „Payment
         terms“ (BT-20) jeweils in einer eigenen Zeile übermittelt werden:
@@ -305,7 +305,7 @@
     </c:rule>
 
     <!-- Example of a general rule not specific to BT or BG -->
-    <c:rule id="BR-DE-19" cius-specific="true">
+    <c:rule id="BR-DE-19" >
       <c:description xml:lang="en">The size of all attached documents together
         may not exceed 15MB</c:description>
       <c:restrictions>

--- a/examples/example-de-cius.xml
+++ b/examples/example-de-cius.xml
@@ -13,7 +13,8 @@
   -->
 <?xml-model href="../schema/ce-config.xsd"?>
 <c:cius xmlns:c="urn:x-namespace:yet:to:be:determined"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:html="http://www.w3.org/1999/xhtml" type="false">
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:html="http://www.w3.org/1999/xhtml"
+  type="false">
 
   <!-- meta element contains basic metainformation about CIUS/Extension -->
   <c:metadata>
@@ -28,18 +29,18 @@
 
     <!-- Version of CIUS/Extension -->
     <c:version>1.1</c:version>
-    
+
     <!-- Status of CIUS/Extension -->
     <c:status>1.1</c:status>
-    
+
     <!-- Date of publication of CIUS/Extension -->
-    <c:date>2017-11-30</c:date>   
+    <c:date>2017-11-30</c:date>
 
     <!-- Author of extension, any HTML markup can be used inside element -->
     <c:publisher>Koordinierungsstelle für IT-Standards, <html:a
-      href="mailto:kosit@finanzen.bremen.de">kosit@finanzen.bremen.de</html:a>
-    </c:publisher>   
- 
+        href="mailto:kosit@finanzen.bremen.de">kosit@finanzen.bremen.de</html:a>
+    </c:publisher>
+
     <!-- Governor of extension -->
     <c:governor>T-Planungsrat</c:governor>
 
@@ -53,144 +54,196 @@
     <c:email>kosit@finanzen.bremen.de</c:email>
 
     <!-- Short description/purpose of spec -->
-    <c:abstract>This CIUS-DE-NAT builds on top of the European Norm EN 16931-1:2017. All rules of the underlying specification apply with the addition of the rules stated in this document.</c:abstract>
+    <c:abstract>This CIUS-DE-NAT builds on top of the European Norm EN 16931-1:2017. All rules of
+      the underlying specification apply with the addition of the rules stated in this
+      document.</c:abstract>
   </c:metadata>
 
   <!-- desc can contain arbitrary HTML with human prose describing CIUS/Extension -->
-  <c:description>Text <html:a language="de"></html:a>
+  <c:description>Text <html:a language="de"/>
     <!-- Empty in this example. -->
   </c:description>
 
-  <c:business-rules> 
+  <c:business-rules>
     <!-- The following set of rules are a technical representation of the set of rules given by the German CIUS XRechnung-->
-    <c:rule id="BR-DE-1" core-elements="BG-16">
-    	<c:description c:language="de">Eine Rechnung (INVOICE) muss Angaben zu „PAYMENT INSTRUCTIONS“ (BG-16) enthalten.</c:description>
-    	<c:description c:language="en">An invoice (INVOICE) must contain information on „PAYMENT INSTRUCTIONS“ (BG-16).</c:description>
+    <c:rule id="BR-DE-1">
+      <c:description c:language="de">Eine Rechnung (INVOICE) muss Angaben zu „PAYMENT INSTRUCTIONS“
+        (BG-16) enthalten.</c:description>
+      <c:description c:language="en">An invoice (INVOICE) must contain information on „PAYMENT
+        INSTRUCTIONS“ (BG-16).</c:description>
       <c:restrictions>
-        <c:cardinality minOccurs="1" />
-      </c:restrictions>
-      </c:rule>
-
-    <c:rule id="BR-DE-2" core-elements="BG-16">
-      <c:description c:language="en">Die Gruppe „SELLER CONTACT“ (BG-6) muss übermittelt werden.</c:description>
-    	<c:description c:language="en">TBD</c:description>
-      <c:restrictions><c:cardinality minOccurs="1"/></c:restrictions>
-    </c:rule>
-
-    <c:rule id="BR-DE-3" core-elements="BT-37">
-    	<c:description c:language="de">Das Element „Seller city“ (BT-37) muss übermittelt werden.</c:description>
-    	<c:description c:language="en">TBD</c:description>
-      <c:restrictions><c:cardinality minOccurs="1"/></c:restrictions>
-       
-    </c:rule>
-
-    <c:rule id="BR-DE-4" core-elements="BT-38">
-    	<c:description c:language="de">Das Element „Seller post code“ (BT-38) muss übermittelt werden.</c:description>
-    	<c:description c:language="en">TBD</c:description>
-      <c:restrictions>
-        <c:cardinality minOccurs="1"/>
+        <c:cardinality minOccurs="1">
+          <c:term>BG-16</c:term>
+        </c:cardinality>
       </c:restrictions>
     </c:rule>
 
-    <c:rule id="BR-DE-5" core-elements="BT-41">
-    	<c:description c:language="de">Das Element „Seller contact point“ (BT-41) muss übermittelt werden.</c:description>
-    	<c:description c:language="en">TBD</c:description>
+    <c:rule id="BR-DE-2">
+      <c:description c:language="en">Die Gruppe „SELLER CONTACT“ (BG-6) muss übermittelt
+        werden.</c:description>
+      <c:description c:language="en">TBD</c:description>
       <c:restrictions>
-        <c:cardinality minOccurs="1"/>
+        <c:cardinality minOccurs="1">
+          <c:term>BG-6</c:term>
+        </c:cardinality>
+
+      </c:restrictions>
+    </c:rule>
+
+    <c:rule id="BR-DE-3">
+      <c:description c:language="de">Das Element „Seller city“ (BT-37) muss übermittelt
+        werden.</c:description>
+      <c:description c:language="en">TBD</c:description>
+      <c:restrictions>
+        <c:cardinality minOccurs="1">
+          <c:term>BT-37</c:term>
+        </c:cardinality>
+      </c:restrictions>
+
+    </c:rule>
+
+    <c:rule id="BR-DE-4">
+      <c:description c:language="de">Das Element „Seller post code“ (BT-38) muss übermittelt
+        werden.</c:description>
+      <c:description c:language="en">TBD</c:description>
+      <c:restrictions>
+        <c:cardinality minOccurs="1">
+          <c:term>BT-38</c:term>
+        </c:cardinality>
+      </c:restrictions>
+    </c:rule>
+
+    <c:rule id="BR-DE-5">
+      <c:description c:language="de">Das Element „Seller contact point“ (BT-41) muss übermittelt
+        werden.</c:description>
+      <c:description c:language="en">TBD</c:description>
+      <c:restrictions>
+        <c:cardinality minOccurs="1">
+          <c:term>BT-41</c:term>
+        </c:cardinality>
       </c:restrictions>
     </c:rule>
 
     <c:rule id="BR-DE-6">
-    	<c:description c:language="de">Das Element „Seller contact telephone number“ (BT-42) muss übermittelt werden.</c:description>
-    	<c:description c:language="en">TBD</c:description>
+      <c:description c:language="de">Das Element „Seller contact telephone number“ (BT-42) muss
+        übermittelt werden.</c:description>
+      <c:description c:language="en">TBD</c:description>
       <c:restrictions>
-        <c:cardinality minOccurs="1"/>
+        <c:cardinality minOccurs="1">
+          <c:term>BT-42</c:term>
+        </c:cardinality>
       </c:restrictions>
     </c:rule>
 
-    <c:rule id="BR-DE-7" core-elements="BT-43">
-    	<c:description c:language="de">Das Element „Seller contact email address“ (BT-43) muss übermittelt werden.</c:description>
-    	<c:description c:language="en">TBD</c:description>
+    <c:rule id="BR-DE-7">
+      <c:description c:language="de">Das Element „Seller contact email address“ (BT-43) muss
+        übermittelt werden.</c:description>
+      <c:description c:language="en">TBD</c:description>
       <c:restrictions>
-        <c:cardinality minOccurs="1"/>
+        <c:cardinality minOccurs="1">
+          <c:term>BT-43</c:term>
+        </c:cardinality>
       </c:restrictions>
     </c:rule>
 
-    <c:rule id="BR-DE-8" core-elements="BT-52">
-    	<c:description c:language="de">Das Element „Buyer city“ (BT-52) muss übermittelt werden.</c:description>
-    	<c:description c:language="en">TBD</c:description>
+    <c:rule id="BR-DE-8">
+      <c:description c:language="de">Das Element „Buyer city“ (BT-52) muss übermittelt
+        werden.</c:description>
+      <c:description c:language="en">TBD</c:description>
       <c:restrictions>
-        <c:cardinality minOccurs="1"/>
+        <c:cardinality minOccurs="1">
+          <c:term>BT-52</c:term>
+        </c:cardinality>
       </c:restrictions>
     </c:rule>
 
-    <c:rule id="BR-DE-9" core-elements="BT-53">
-    	<c:description c:language="de">Das Element „Buyer post code“ (BT-53) muss übermittelt werden.</c:description>
-    	<c:description c:language="en">TBD</c:description>
+    <c:rule id="BR-DE-9">
+      <c:description c:language="de">Das Element „Buyer post code“ (BT-53) muss übermittelt
+        werden.</c:description>
+      <c:description c:language="en">TBD</c:description>
       <c:restrictions>
-        <c:cardinality minOccurs="1"/>
+        <c:cardinality minOccurs="1">
+          <c:term>BT-53</c:term>
+        </c:cardinality>
       </c:restrictions>
     </c:rule>
 
-    <c:rule id="BR-DE-10" core-elements="BT-77">
-    	<c:description c:language="de">Das Element „Deliver to city“ (BT-77) muss übermittelt werden.</c:description>
-    	<c:description c:language="en">TBD</c:description>
+    <c:rule id="BR-DE-10">
+      <c:description c:language="de">Das Element „Deliver to city“ (BT-77) muss übermittelt
+        werden.</c:description>
+      <c:description c:language="en">TBD</c:description>
       <c:restrictions>
-        <c:cardinality minOccurs="1"/>
-      </c:restrictions>
-    </c:rule>
-    
-    <c:rule id="BR-DE-11" core-elements="BT-78">
-     	<c:description c:language="de">Das Element „Deliver to post code“ (BT-78) muss übermittelt werden.</c:description>
-    	<c:description c:language="en">TBD</c:description>
-      <c:restrictions>
-        <c:cardinality minOccurs="1"/>
+        <c:cardinality minOccurs="1">
+          <c:term>BT-77</c:term>
+        </c:cardinality>
       </c:restrictions>
     </c:rule>
 
-    <c:rule id="BR-DE-12" core-elements="BT-78">
-    	<c:description c:language="de">Mit dem Element „Deliver to post code“ (BT-78) muss eine Postleitzahl übermittelt werden.</c:description>
-    	<c:description c:language="en">TBD</c:description>
+    <c:rule id="BR-DE-11">
+      <c:description c:language="de">Das Element „Deliver to post code“ (BT-78) muss übermittelt
+        werden.</c:description>
+      <c:description c:language="en">TBD</c:description>
       <c:restrictions>
-        <c:cardinality minOccurs="1"/>
+        <c:cardinality minOccurs="1">
+          <c:term>BT-78</c:term>
+        </c:cardinality>
+      </c:restrictions>
+    </c:rule>
+
+    <c:rule id="BR-DE-12">
+      <c:description c:language="de">Mit dem Element „Deliver to post code“ (BT-78) muss eine
+        Postleitzahl übermittelt werden.</c:description>
+      <c:description c:language="en">TBD</c:description>
+      <c:restrictions>
+        <c:cardinality minOccurs="1">
+          <c:term>BT-78</c:term>
+        </c:cardinality>
       </c:restrictions>
     </c:rule>
 
     <c:rule id="BR-DE-13">
-    	<c:description c:language="de">In der Rechnung müssen Angaben zu einer der drei Gruppen „CREDIT TRANSFER“ (BG-17), „PAYMENT CARD INFORMATION“ (BG-18) oder „DIRECT DEBIT“ (BG-19) übermittelt werden.</c:description>
-    	<c:description c:language="en">TBD</c:description>
+      <c:description c:language="de">In der Rechnung müssen Angaben zu einer der drei Gruppen
+        „CREDIT TRANSFER“ (BG-17), „PAYMENT CARD INFORMATION“ (BG-18) oder „DIRECT DEBIT“ (BG-19)
+        übermittelt werden.</c:description>
+      <c:description c:language="en">TBD</c:description>
       <c:restrictions>
-        <c:other> 
+        <c:other>
           <c:description>
-            <c:term>BG-17</c:term> 
+            <c:term>BG-17</c:term>
             <c:term>BG-18</c:term>
             <c:term>BG-19</c:term>
           </c:description>
-          
-        </c:other>  
+        </c:other>
       </c:restrictions>
-      
     </c:rule>
 
-    <c:rule id="BR-DE-14" core-elements="BT-119">
-    	<c:description c:language="de">Das Element „VAT category rate“ (BT-119) muss übermittelt werden.</c:description>
-    	<c:description c:language="en">TBD</c:description>
+    <c:rule id="BR-DE-14">
+      <c:description c:language="de">Das Element „VAT category rate“ (BT-119) muss übermittelt
+        werden.</c:description>
+      <c:description c:language="en">TBD</c:description>
       <c:restrictions>
-        <c:cardinality minOccurs="1"/>
+        <c:cardinality minOccurs="1">
+          <c:term>BT-119</c:term>
+        </c:cardinality>
       </c:restrictions>
     </c:rule>
 
-    <c:rule id="BR-DE-15" core-elements="BT-10">
-    	<c:description c:language="de">Das Element „Buyer reference“ (BT-10) muss übermittelt werden.</c:description>
-    	<c:description c:language="en">TBD</c:description>
+    <c:rule id="BR-DE-15">
+      <c:description c:language="de">Das Element „Buyer reference“ (BT-10) muss übermittelt
+        werden.</c:description>
+      <c:description c:language="en">TBD</c:description>
       <c:restrictions>
-        <c:cardinality minOccurs="1"/>
+        <c:cardinality minOccurs="1">
+          <c:term>BT-10</c:term>
+        </c:cardinality>
       </c:restrictions>
     </c:rule>
 
-    <c:rule id="BR-DE-16" core-elements="BT-31 BT-32 BG-11">
-    	<c:description c:language="de">Das Element „Seller VAT identifier“ (BT-31) muss übermittelt werden, wenn nicht das Element „Seller tax registration identifier“ (BT-32) oder eine Gruppe „SELLER TAX REPRESENTATIVE PARTY“ (BG-11) übermittelt wurden.</c:description>
-    	<c:description c:language="en">TBD</c:description>
+    <c:rule id="BR-DE-16">
+      <c:description c:language="de">Das Element „Seller VAT identifier“ (BT-31) muss übermittelt
+        werden, wenn nicht das Element „Seller tax registration identifier“ (BT-32) oder eine Gruppe
+        „SELLER TAX REPRESENTATIVE PARTY“ (BG-11) übermittelt wurden.</c:description>
+      <c:description c:language="en">TBD</c:description>
       <c:restrictions>
         <c:other>
           <c:description>
@@ -200,21 +253,33 @@
           </c:description>
         </c:other>
       </c:restrictions>
-       </c:rule>
+    </c:rule>
 
-    <c:rule id="BR-DE-17" core-elements="BT-3">
-    	<c:description c:language="de">Mit dem Element „Invoice type code“ (BT-3) sollen ausschließlich folgende Codes aus der Codeliste UNTDID 1001a übermittelt werden: 326 (Partial invoice), 380 (Commercial invoice), 384 (Corrected invoice), 381 (Credit note)</c:description>
-    	<c:description c:language="en">TBD</c:description>
+    <c:rule id="BR-DE-17">
+      <c:description c:language="de">Mit dem Element „Invoice type code“ (BT-3) sollen
+        ausschließlich folgende Codes aus der Codeliste UNTDID 1001a übermittelt werden: 326
+        (Partial invoice), 380 (Commercial invoice), 384 (Corrected invoice), 381 (Credit
+        note)</c:description>
+      <c:description c:language="en">TBD</c:description>
       <c:restrictions>
         <c:codelist>
+          <c:term>BT-3</c:term>
           <c:allowed-codes>326 380 384 381</c:allowed-codes>
         </c:codelist>
       </c:restrictions>
     </c:rule>
 
-    <c:rule id="BR-DE-18" core-elements="BT-20 BT-115">
-    	<c:description c:language="de">Informationen zur Gewährung von Skonto oder zur Berechnung von Verzugszinsen müssen wie folgt im Element „Payment terms“ (BT-20) jeweils in einer eigenen Zeile übermittelt werden: Anzugeben ist im ersten Segment „SKONTO“ oder „VERZUG“, im zweiten „TAGE=n“, im dritten „PROZENT=n“, wobei die Segmente jeweils von einer „#“ umfasst sind. Prozentzahlen sind mit Punkt getrennt von zwei Nachkommastellen anzugeben. Liegt dem zu berechnenden Betrag nicht BT-115, „fälliger Betrag“ zugrunde, sondern nur ein Teil des fälligen Betrags der Rechnung, ist der Grundwert zur Berechnung von Skonto oder Verzugszins als viertes Segment „BASISBETRAG=n“ mit dem semantischen Datentyp Amount anzugeben.</c:description>
-    	<c:description c:language="en">TBD</c:description>
+    <c:rule id="BR-DE-18">
+      <c:description c:language="de">Informationen zur Gewährung von Skonto oder zur Berechnung von
+        Verzugszinsen müssen wie folgt im Element „Payment terms“ (BT-20) jeweils in einer eigenen
+        Zeile übermittelt werden: Anzugeben ist im ersten Segment „SKONTO“ oder „VERZUG“, im zweiten
+        „TAGE=n“, im dritten „PROZENT=n“, wobei die Segmente jeweils von einer „#“ umfasst sind.
+        Prozentzahlen sind mit Punkt getrennt von zwei Nachkommastellen anzugeben. Liegt dem zu
+        berechnenden Betrag nicht BT-115, „fälliger Betrag“ zugrunde, sondern nur ein Teil des
+        fälligen Betrags der Rechnung, ist der Grundwert zur Berechnung von Skonto oder Verzugszins
+        als viertes Segment „BASISBETRAG=n“ mit dem semantischen Datentyp Amount
+        anzugeben.</c:description>
+      <c:description c:language="en">TBD</c:description>
       <c:restrictions>
         <c:other>
           <c:description>
@@ -229,11 +294,13 @@
       <c:description>The size of all attached documents together may not exceed 15MB</c:description>
       <c:restrictions>
         <c:other>
-          <c:description><type>technical</type></c:description>
+          <c:description>
+            <type>technical</type>
+          </c:description>
         </c:other>
       </c:restrictions>
     </c:rule>
-    
+
   </c:business-rules>
 
 </c:cius>

--- a/examples/example-de-cius.xml
+++ b/examples/example-de-cius.xml
@@ -13,8 +13,8 @@
   -->
 <?xml-model href="../schema/ce-config.xsd"?>
 <c:cius xmlns:c="urn:x-namespace:yet:to:be:determined"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:html="http://www.w3.org/1999/xhtml"
-  type="false">
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:html="http://www.w3.org/1999/xhtml" type="false">
 
   <!-- meta element contains basic metainformation about CIUS/Extension -->
   <c:metadata>
@@ -26,7 +26,7 @@
 
     <!-- Identifier as described in "7.6 Identification of core invoice usage specifications" -->
     <c:nameTechnical>urn:ce.eu:en16931:2017:xoev-de:kosit:standard:xrechnung_1.1</c:nameTechnical>
-    
+
     <!-- Underlying Specification -->
     <c:underlyingSpecification>urn:ce.eu:en16931:2017</c:underlyingSpecification>
 
@@ -41,8 +41,7 @@
 
     <!-- Author of extension, any HTML markup can be used inside element -->
     <c:publisher>Koordinierungsstelle für IT-Standards, <html:a
-
-      href="mailto:kosit@finanzen.bremen.de">kosit@finanzen.bremen.de</html:a>
+        href="mailto:kosit@finanzen.bremen.de">kosit@finanzen.bremen.de</html:a>
     </c:publisher>
 
     <!-- Governor of extension -->
@@ -58,37 +57,39 @@
     <c:contact>kosit@finanzen.bremen.de</c:contact>
 
     <!-- Short description/purpose of spec -->
-    <c:abstract xml:lang="en">This CIUS-DE-NAT builds on top of the European Norm EN 16931-1:2017. All rules of
-      the underlying specification apply with the addition of the rules stated in this
-      document.</c:abstract>
-    
+    <c:abstract xml:lang="en">This CIUS-DE-NAT builds on top of the European
+      Norm EN 16931-1:2017. All rules of the underlying specification apply with
+      the addition of the rules stated in this document.</c:abstract>
+
     <!-- A hyperlink to more detailed information about the specification. Preferably that should include contact information. -->
     <c:furtherInformation>https://www.xoev.de/de/xrechnung</c:furtherInformation>
   </c:metadata>
- 
+
   <!-- desc can contain arbitrary HTML with human prose describing CIUS/Extension -->
-  <c:description xml:lang="en">Text with<html:b >HTML</html:b> content
+  <c:description xml:lang="en">Text with<html:b>HTML</html:b> content
     <!-- Empty in this example. -->
   </c:description>
 
   <c:business-rules>
     <!-- The following set of rules are a technical representation of the set of rules given by the German CIUS XRechnung-->
     <c:rule id="BR-DE-1">
-      <c:description xml:lang="de">Eine Rechnung (INVOICE) muss Angaben zu „PAYMENT INSTRUCTIONS“
-        (BG-16) enthalten.</c:description>
-      <c:description xml:lang="en">An invoice shall contain information on “PAYMENT INTSTRUCTIONS” (BG-16).</c:description>
+      <c:description xml:lang="de">Eine Rechnung (INVOICE) muss Angaben zu
+        „PAYMENT INSTRUCTIONS“ (BG-16) enthalten.</c:description>
+      <c:description xml:lang="en">The INVOICE shall contain information on
+        PAYMENT INSTRUCTIONS (BG-16).</c:description>
       <c:restrictions>
         <c:cardinality minOccurs="1">
           <c:term>BG-16</c:term>
         </c:cardinality>
-        
+
       </c:restrictions>
     </c:rule>
 
     <c:rule id="BR-DE-2">
-      <c:description xml:lang="en">Die Gruppe „SELLER CONTACT“ (BG-6) muss übermittelt
-        werden.</c:description>
-      <c:description xml:lang="en">The group “SELLER CONTACT” (BG-6) shall be provided.</c:description>
+      <c:description xml:lang="en">Die Gruppe „SELLER CONTACT“ (BG-6) muss
+        übermittelt werden.</c:description>
+      <c:description xml:lang="en">The group SELLER CONTACT1 (BG-6) shall be
+        transmitted.</c:description>
       <c:restrictions>
         <c:cardinality minOccurs="1">
           <c:term>BG-6</c:term>
@@ -98,9 +99,10 @@
     </c:rule>
 
     <c:rule id="BR-DE-3">
-      <c:description xml:lang="de">Das Element „Seller city“ (BT-37) muss übermittelt
-        werden.</c:description>
-      <c:description xml:lang="en">The element “seller city” (BT-37) shall be provided.</c:description>
+      <c:description xml:lang="de">Das Element „Seller city“ (BT-37) muss
+        übermittelt werden.</c:description>
+      <c:description xml:lang="en">The element “Seller city” (BT-37) shall be
+        transmitted.</c:description>
       <c:restrictions>
         <c:cardinality minOccurs="1">
           <c:term>BT-37</c:term>
@@ -110,9 +112,10 @@
     </c:rule>
 
     <c:rule id="BR-DE-4">
-      <c:description xml:lang="de">Das Element „Seller post code“ (BT-38) muss übermittelt
-        werden.</c:description>
-      <c:description xml:lang="en">The element “Seller post code“ (BT-38) shall be provided.</c:description>
+      <c:description xml:lang="de">Das Element „Seller post code“ (BT-38) muss
+        übermittelt werden.</c:description>
+      <c:description xml:lang="en">The element “Seller post code” (BT-38) shall
+        be transmitted.</c:description>
       <c:restrictions>
         <c:cardinality minOccurs="1">
           <c:term>BT-38</c:term>
@@ -121,9 +124,10 @@
     </c:rule>
 
     <c:rule id="BR-DE-5">
-      <c:description xml:lang="de">Das Element „Seller contact point“ (BT-41) muss übermittelt
-        werden.</c:description>
-      <c:description xml:lang="en">The element “Seller contact point“ (BT-41) shall be provided.</c:description>
+      <c:description xml:lang="de">Das Element „Seller contact point“ (BT-41)
+        muss übermittelt werden.</c:description>
+      <c:description xml:lang="en">The element “Seller contact point” (BT-41)
+        shall be transmitted.</c:description>
       <c:restrictions>
         <c:cardinality minOccurs="1">
           <c:term>BT-41</c:term>
@@ -132,9 +136,10 @@
     </c:rule>
 
     <c:rule id="BR-DE-6">
-      <c:description xml:lang="de">Das Element „Seller contact telephone number“ (BT-42) muss
-        übermittelt werden.</c:description>
-      <c:description xml:lang="en">The element “Seller contact telephone number“ (BT-42) shall be provided.</c:description>
+      <c:description xml:lang="de">Das Element „Seller contact telephone number“
+        (BT-42) muss übermittelt werden.</c:description>
+      <c:description xml:lang="en">The element „Seller contact telephone
+        number“(BT-BT) shall be transmitted.</c:description>
       <c:restrictions>
         <c:cardinality minOccurs="1">
           <c:term>BT-42</c:term>
@@ -143,9 +148,10 @@
     </c:rule>
 
     <c:rule id="BR-DE-7">
-      <c:description xml:lang="de">Das Element „Seller contact email address“ (BT-43) muss
-        übermittelt werden.</c:description>
-      <c:description xml:lang="en">The element “Seller contact email address“ (BT-43) shall be provided.</c:description>
+      <c:description xml:lang="de">Das Element „Seller contact email address“
+        (BT-43) muss übermittelt werden.</c:description>
+      <c:description xml:lang="en">The element “Seller contact email address”
+        (BT-43) shall be transmitted.</c:description>
       <c:restrictions>
         <c:cardinality minOccurs="1">
           <c:term>BT-43</c:term>
@@ -154,9 +160,10 @@
     </c:rule>
 
     <c:rule id="BR-DE-8">
-      <c:description xml:lang="de">Das Element „Buyer city“ (BT-52) muss übermittelt
-        werden.</c:description>
-      <c:description xml:lang="en">The element “Buyer city“ (BT-52) shall be provided.</c:description>
+      <c:description xml:lang="de">Das Element „Buyer city“ (BT-52) muss
+        übermittelt werden.</c:description>
+      <c:description xml:lang="en">The element “Buyer city” (BT-52) shall be
+        transmitted.</c:description>
       <c:restrictions>
         <c:cardinality minOccurs="1">
           <c:term>BT-52</c:term>
@@ -165,9 +172,10 @@
     </c:rule>
 
     <c:rule id="BR-DE-9">
-      <c:description xml:lang="de">Das Element „Buyer post code“ (BT-53) muss übermittelt
-        werden.</c:description>
-      <c:description xml:lang="en">The element “Buyer post code“ (BT-53) shall be provided.</c:description>
+      <c:description xml:lang="de">Das Element „Buyer post code“ (BT-53) muss
+        übermittelt werden.</c:description>
+      <c:description xml:lang="en">The element “Buyer post code” (BT-53) shall
+        be transmitted.</c:description>
       <c:restrictions>
         <c:cardinality minOccurs="1">
           <c:term>BT-53</c:term>
@@ -176,9 +184,10 @@
     </c:rule>
 
     <c:rule id="BR-DE-10">
-      <c:description xml:lang="de">Das Element „Deliver to city“ (BT-77) muss übermittelt
-        werden.</c:description>
-      <c:description xml:lang="en">The element “Deliver to city“ (BT-77) shall be provided.</c:description>
+      <c:description xml:lang="de">Das Element „Deliver to city“ (BT-77) muss
+        übermittelt werden.</c:description>
+      <c:description xml:lang="en">The element “Deliver to city“” (BT-77) shall
+        be transmitted.</c:description>
       <c:restrictions>
         <c:cardinality minOccurs="1">
           <c:term>BT-77</c:term>
@@ -187,9 +196,10 @@
     </c:rule>
 
     <c:rule id="BR-DE-11">
-      <c:description xml:lang="de">Das Element „Deliver to post code“ (BT-78) muss übermittelt
-        werden.</c:description>
-      <c:description xml:lang="en">TBD</c:description>
+      <c:description xml:lang="de">Das Element „Deliver to post code“ (BT-78)
+        muss übermittelt werden.</c:description>
+      <c:description xml:lang="en">The element “Deliver to post code” (BT-78)
+        shall be transmitted.</c:description>
 
       <c:restrictions>
         <c:cardinality minOccurs="1">
@@ -198,10 +208,11 @@
       </c:restrictions>
     </c:rule>
 
-    <c:rule id="BR-DE-12" >
-      <c:description xml:lang="de">Mit dem Element „Deliver to post code“ (BT-78) muss eine
-        Postleitzahl übermittelt werden.</c:description>
-      <c:description xml:lang="en">The element “Deliver to post code” (BT-78) shall contain a German postal code.</c:description>
+    <c:rule id="BR-DE-12">
+      <c:description xml:lang="de">Mit dem Element „Deliver to post code“
+        (BT-78) muss eine Postleitzahl übermittelt werden.</c:description>
+      <c:description xml:lang="en">A post code shall be transmitted together
+        with the element “Deliver to post code” (BT-78).</c:description>
       <c:restrictions>
         <c:cardinality minOccurs="1">
           <c:term>BT-78</c:term>
@@ -210,10 +221,12 @@
     </c:rule>
 
     <c:rule id="BR-DE-13">
-      <c:description xml:lang="de">In der Rechnung müssen Angaben zu einer der drei Gruppen
-        „CREDIT TRANSFER“ (BG-17), „PAYMENT CARD INFORMATION“ (BG-18) oder „DIRECT DEBIT“ (BG-19)
-        übermittelt werden.</c:description>
-      <c:description xml:lang="en">An invoice shall contain information on „CREDIT TRANSFER“ (BG-17), „PAYMENT CARD INFORMATION“ (BG-18) or „DIRECT DEBIT“ (BG-19).</c:description>
+      <c:description xml:lang="de">In der Rechnung müssen Angaben zu einer der
+        drei Gruppen „CREDIT TRANSFER“ (BG-17), „PAYMENT CARD INFORMATION“
+        (BG-18) oder „DIRECT DEBIT“ (BG-19) übermittelt werden.</c:description>
+      <c:description xml:lang="en">The invoice shall contain information on one
+        of the three groups: “CREDIT TRANSFER” (BG-17), “PAYMENT CARD
+        INFORMATION” (BG-18) or “DIRECT DEBIT” (BG-19).</c:description>
       <c:restrictions>
         <c:other>
           <c:description>
@@ -228,9 +241,10 @@
     </c:rule>
 
     <c:rule id="BR-DE-14">
-      <c:description xml:lang="de">Das Element „VAT category rate“ (BT-119) muss übermittelt
-        werden.</c:description>
-      <c:description xml:lang="en">The element “VAT category rate “ (BT-119) shall be provided.</c:description>
+      <c:description xml:lang="de">Das Element „VAT category rate“ (BT-119) muss
+        übermittelt werden.</c:description>
+      <c:description xml:lang="en">The element “VAT category rate” (BT-119)
+        shall be transmitted.</c:description>
       <c:restrictions>
         <c:cardinality minOccurs="1">
           <c:term>BT-119</c:term>
@@ -239,9 +253,10 @@
     </c:rule>
 
     <c:rule id="BR-DE-15">
-      <c:description xml:lang="de">Das Element „Buyer reference“ (BT-10) muss übermittelt
-        werden.</c:description>
-      <c:description xml:lang="en">The element “Buyer reference“ (BT-10) shall be provided.</c:description>
+      <c:description xml:lang="de">Das Element „Buyer reference“ (BT-10) muss
+        übermittelt werden.</c:description>
+      <c:description xml:lang="en">The element „Buyer reference“ (BT-10) shall
+        be transmitted.</c:description>
       <c:restrictions>
         <c:cardinality minOccurs="1">
           <c:term>BT-10</c:term>
@@ -250,10 +265,14 @@
     </c:rule>
 
     <c:rule id="BR-DE-16">
-      <c:description xml:lang="de">Das Element „Seller VAT identifier“ (BT-31) muss übermittelt
-        werden, wenn nicht das Element „Seller tax registration identifier“ (BT-32) oder eine Gruppe
-        „SELLER TAX REPRESENTATIVE PARTY“ (BG-11) übermittelt wurden.</c:description>
-      <c:description xml:lang="en">The element “Seller VAT identifier“ (BT-31) shall be provided if the element “Seller tax registration identifier“ (BT-32) or the group “SELLER TAX REPRESENTATIVE PARTY“ (BG-11) is not provided.</c:description>
+      <c:description xml:lang="de">Das Element „Seller VAT identifier“ (BT-31)
+        muss übermittelt werden, wenn nicht das Element „Seller tax registration
+        identifier“ (BT-32) oder eine Gruppe „SELLER TAX REPRESENTATIVE PARTY“
+        (BG-11) übermittelt wurden.</c:description>
+      <c:description xml:lang="en">The element “Seller VAT identifier” (BT-31)
+        shall be transmitted, if the element “Seller tax registration
+        identifier” (BT-32) or a group „SELLER TAX REPRESENTATIVE PARTY“ (BG-11)
+        is not transmitted.</c:description>
       <c:restrictions>
         <c:other>
           <c:description>
@@ -266,11 +285,14 @@
     </c:rule>
 
     <c:rule id="BR-DE-17" core-elements="BT-3" c:cius-specific="true">
-      <c:description xml:lang="de">Mit dem Element „Invoice type code“ (BT-3) sollen
-        ausschließlich folgende Codes aus der Codeliste UNTDID 1001 übermittelt werden: 326
-        (Partial invoice), 380 (Commercial invoice), 384 (Corrected invoice), 381 (Credit
-        note)</c:description>
-      <c:description xml:lang="en">The element “Invoice type code” (BT-3) should only contain the following values from code list UNTDID 1001: 326 (Partial invoice), 380 (Commercial invoice), 384 (Corrected invoice), 381 (Credit note)</c:description>
+      <c:description xml:lang="de">Mit dem Element „Invoice type code“ (BT-3)
+        sollen ausschließlich folgende Codes aus der Codeliste UNTDID 1001
+        übermittelt werden: 326 (Partial invoice), 380 (Commercial invoice), 384
+        (Corrected invoice), 381 (Credit note)</c:description>
+      <c:description xml:lang="en">With the element “Invoice type code” (BT-3)
+        only the following codes from the code list UNTDID 1001 shall be
+        transmitted: 326 (Partial invoice), 380 (Commercial invoice),
+        384(Corrected invoice), 381 (Credit note) </c:description>
       <c:restrictions>
         <c:codelist>
           <c:allowed-codes>326 380 384 381</c:allowed-codes>
@@ -279,17 +301,28 @@
     </c:rule>
 
     <c:rule id="BR-DE-18">
-      <c:description xml:lang="de">Informationen zur Gewährung von Skonto oder zur Berechnung von
-        Verzugszinsen müssen wie folgt im Element „Payment terms“ (BT-20) jeweils in einer eigenen
-        Zeile übermittelt werden: Anzugeben ist im ersten Segment „SKONTO“ oder „VERZUG“, im zweiten
-        „TAGE=n“, im dritten „PROZENT=n“, wobei die Segmente jeweils von einer „#“ umfasst sind.
-        Prozentzahlen sind mit Punkt getrennt von zwei Nachkommastellen anzugeben. Liegt dem zu
-        berechnenden Betrag nicht BT-115, „fälliger Betrag“ zugrunde, sondern nur ein Teil des
-        fälligen Betrags der Rechnung, ist der Grundwert zur Berechnung von Skonto oder Verzugszins
-        als viertes Segment „BASISBETRAG=n“ mit dem semantischen Datentyp Amount
-        anzugeben.</c:description>
-      <c:description xml:lang="en">Information on cash discount for prompt payment (Skonto) or default charges (Verzugszinsen) shall be provided within the element “Payment terms” BT-20 in the following way (one row per entry): First segment “SKONTO” or “VERZUG”, second segment amount of days (“TAGE=N”), third segment percentage (“PROZENT=N”) with segments enfolded by #. Percentage shall be separated by dot with two decimal places. In case the base value of the invoiced amount is not provided in BT-115 but as partial amount, the base value shall be provided as fourth segment “BASISBETRAG=N” as semantic data type amount.
-</c:description>
+      <c:description xml:lang="de">Informationen zur Gewährung von Skonto oder
+        zur Berechnung von Verzugszinsen müssen wie folgt im Element „Payment
+        terms“ (BT-20) jeweils in einer eigenen Zeile übermittelt werden:
+        Anzugeben ist im ersten Segment „SKONTO“ oder „VERZUG“, im zweiten
+        „TAGE=n“, im dritten „PROZENT=n“, wobei die Segmente jeweils von einer
+        „#“ umfasst sind. Prozentzahlen sind mit Punkt getrennt von zwei
+        Nachkommastellen anzugeben. Liegt dem zu berechnenden Betrag nicht
+        BT-115, „fälliger Betrag“ zugrunde, sondern nur ein Teil des fälligen
+        Betrags der Rechnung, ist der Grundwert zur Berechnung von Skonto oder
+        Verzugszins als viertes Segment „BASISBETRAG=n“ mit dem semantischen
+        Datentyp Amount anzugeben.</c:description>
+      <c:description xml:lang="en">Information on any discount or interest on
+        late payments shall be given in the element “Payment terms” (BT-20) in a
+        separate line as follows: In the first segment, state “DISCOUNT” or
+        “LATE PAYMENTS”, in the second segment state “DAYS=n”, in the third
+        segment state “PERCENT=n”; each segment must be enclosed in hashes (#).
+        Percentages shall be given as a decimal number with two places after the
+        point. If the calculated amount is not based on BT-115 “amount payable”,
+        but is only part of the payable amount given in the invoice, the basic
+        amount shall be stated in a fourth segment “BASIC AMOUNT=n” with the
+        semantic data type AMOUNT for the calculation of discount or interest on
+        late payment. </c:description>
       <c:restrictions>
         <c:other>
           <c:description>
@@ -300,8 +333,10 @@
       </c:restrictions>
     </c:rule>
 
+    <!-- Example of a general rule not specific to BT or BG -->
     <c:rule id="BR-DE-19">
-      <c:description xml:lang="en">The size of all attached documents together may not exceed 15MB</c:description>
+      <c:description xml:lang="en">The size of all attached documents together
+        may not exceed 15MB</c:description>
       <c:restrictions>
         <c:other>
           <c:description>

--- a/examples/example-de-cius.xml
+++ b/examples/example-de-cius.xml
@@ -11,10 +11,9 @@
   This example uses prevoius work of AT National CIUS provided by Philip Helger	
 
   -->
-<?xml-model href="../schema/ce-config.rnc"?>
+<?xml-model href="../schema/ce-config.xsd"?>
 <c:config xmlns:c="urn:x-namespace:yet:to:be:determined"
-  xmlns:sch="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml" cius="true"
-  extension="false">
+  xmlns:sch="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml" type="true">
 
   <!-- meta element contains basic metainformation about CIUS/Extension -->
   <c:meta>
@@ -39,7 +38,7 @@
     </c:publisher>
 
     <!-- Governor of extension -->
-    <c:governor> IT-Planungsrat </c:governor>
+    <c:governor>T-Planungsrat</c:governor>
 
     <!-- Country where CIUS/Extension is used -->
     <c:country>DE</c:country>

--- a/examples/example-de-cius.xml
+++ b/examples/example-de-cius.xml
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <!--
-  
-  This is very rough and sketchy proposal for machine readable format 
-  for describing CIUS and/or Extensions to core EU invoice 
+
+  This is very rough and sketchy proposal for machine readable format
+  for describing CIUS and/or Extensions to core EU invoice
 
   In this example German National CIUS (XRechnung) is shown using proposed syntax
-  
+
   This is just example and working draft with no official standing
 
-  This example uses prevoius work of AT National CIUS provided by Philip Helger	
+  This example uses prevoius work of AT National CIUS provided by Philip Helger
 
   -->
 <?xml-model href="../schema/ce-config.xsd"?>
@@ -28,18 +28,18 @@
 
     <!-- Version of CIUS/Extension -->
     <c:version>1.1</c:version>
-    
+
     <!-- Status of CIUS/Extension -->
     <c:status>1.1</c:status>
-    
+
     <!-- Date of publication of CIUS/Extension -->
-    <c:date>2017-11-30</c:date>   
+    <c:date>2017-11-30</c:date>
 
     <!-- Author of extension, any HTML markup can be used inside element -->
     <c:publisher>Koordinierungsstelle für IT-Standards, <html:a
       href="mailto:kosit@finanzen.bremen.de">kosit@finanzen.bremen.de</html:a>
-    </c:publisher>   
- 
+    </c:publisher>
+
     <!-- Governor of extension -->
     <c:governor>T-Planungsrat</c:governor>
 
@@ -61,7 +61,7 @@
     <!-- Empty in this example. -->
   </c:description>
 
-  <c:business-rules> 
+  <c:business-rules>
     <!-- The following set of rules are a technical representation of the set of rules given by the German CIUS XRechnung-->
     <c:rule id="BR-DE-1" core-elements="BG-16">
     	<c:description c:language="de">Eine Rechnung (INVOICE) muss Angaben zu „PAYMENT INSTRUCTIONS“ (BG-16) enthalten.</c:description>
@@ -81,7 +81,7 @@
     	<c:description c:language="de">Das Element „Seller city“ (BT-37) muss übermittelt werden.</c:description>
     	<c:description c:language="en">TBD</c:description>
       <c:restrictions><c:cardinality minOccurs="1"/></c:restrictions>
-       
+
     </c:rule>
 
     <c:rule id="BR-DE-4" core-elements="BT-38">
@@ -139,7 +139,7 @@
         <c:cardinality minOccurs="1"/>
       </c:restrictions>
     </c:rule>
-    
+
     <c:rule id="BR-DE-11" core-elements="BT-78">
      	<c:description c:language="de">Das Element „Deliver to post code“ (BT-78) muss übermittelt werden.</c:description>
     	<c:description c:language="en">TBD</c:description>
@@ -160,16 +160,16 @@
     	<c:description c:language="de">In der Rechnung müssen Angaben zu einer der drei Gruppen „CREDIT TRANSFER“ (BG-17), „PAYMENT CARD INFORMATION“ (BG-18) oder „DIRECT DEBIT“ (BG-19) übermittelt werden.</c:description>
     	<c:description c:language="en">TBD</c:description>
       <c:restrictions>
-        <c:other> 
+        <c:other>
           <c:description>
-            <c:term>BG-17</c:term> 
+            <c:term>BG-17</c:term>
             <c:term>BG-18</c:term>
             <c:term>BG-19</c:term>
           </c:description>
-          
-        </c:other>  
+
+        </c:other>
       </c:restrictions>
-      
+
     </c:rule>
 
     <c:rule id="BR-DE-14" core-elements="BT-119">
@@ -233,7 +233,7 @@
         </c:other>
       </c:restrictions>
     </c:rule>
-    
+
   </c:business-rules>
 
 </c:cius>

--- a/examples/example-de-cius.xml
+++ b/examples/example-de-cius.xml
@@ -14,7 +14,7 @@
 <?xml-model href="../schema/ce-config.xsd"?>
 <c:cius xmlns:c="urn:x-namespace:yet:to:be:determined"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xmlns:html="http://www.w3.org/1999/xhtml" >
+  xmlns:html="http://www.w3.org/1999/xhtml">
 
   <!-- meta element contains basic metainformation about CIUS/Extension -->
   <c:metadata>
@@ -78,7 +78,7 @@
       <c:description xml:lang="en">The INVOICE shall contain information on
         PAYMENT INSTRUCTIONS (BG-16).</c:description>
       <c:restrictions>
-        <c:cardinality minOccurs="1" term="BG-16"/>        
+        <c:cardinality minOccurs="1" term="BG-16"/>
 
       </c:restrictions>
     </c:rule>
@@ -181,7 +181,7 @@
         shall be transmitted.</c:description>
 
       <c:restrictions>
-        <c:cardinality minOccurs="1" term="BT-78"/>        
+        <c:cardinality minOccurs="1" term="BT-78"/>
       </c:restrictions>
     </c:rule>
 
@@ -255,7 +255,7 @@
       </c:restrictions>
     </c:rule>
 
-    <c:rule id="BR-DE-17" core-elements="BT-3" cius-specific="true">
+    <c:rule id="BR-DE-17"  cius-specific="true">
       <c:description xml:lang="de">Mit dem Element „Invoice type code“ (BT-3)
         sollen ausschließlich folgende Codes aus der Codeliste UNTDID 1001
         übermittelt werden: 326 (Partial invoice), 380 (Commercial invoice), 384

--- a/examples/example-de-cius.xml
+++ b/examples/example-de-cius.xml
@@ -9,7 +9,7 @@
   This is just example and working draft with no official standing
 
   This example uses prevoius work of AT National CIUS provided by Philip Helger
-
+ 
   -->
 <?xml-model href="../schema/ce-config.xsd"?>
 <c:cius xmlns:c="urn:x-namespace:yet:to:be:determined"
@@ -70,9 +70,9 @@
     <!-- Empty in this example. -->
   </c:description>
 
+  <!-- The following set of rules are a technical representation of the set of rules given by the German CIUS XRechnung-->
   <c:business-rules>
-    <!-- The following set of rules are a technical representation of the set of rules given by the German CIUS XRechnung-->
-    <c:rule id="BR-DE-1">
+    <c:rule id="BR-DE-1" >
       <c:description xml:lang="de">Eine Rechnung (INVOICE) muss Angaben zu
         „PAYMENT INSTRUCTIONS“ (BG-16) enthalten.</c:description>
       <c:description xml:lang="en">The INVOICE shall contain information on

--- a/examples/example-de-cius.xml
+++ b/examples/example-de-cius.xml
@@ -69,8 +69,7 @@
     <c:rule id="BR-DE-1">
       <c:description c:language="de">Eine Rechnung (INVOICE) muss Angaben zu „PAYMENT INSTRUCTIONS“
         (BG-16) enthalten.</c:description>
-      <c:description c:language="en">An invoice (INVOICE) must contain information on „PAYMENT
-        INSTRUCTIONS“ (BG-16).</c:description>
+      <c:description c:language="en">An invoice shall contain information on “PAYMENT INTSTRUCTIONS” (BG-16).</c:description>
       <c:restrictions>
         <c:cardinality minOccurs="1">
           <c:term>BG-16</c:term>
@@ -81,7 +80,7 @@
     <c:rule id="BR-DE-2">
       <c:description c:language="en">Die Gruppe „SELLER CONTACT“ (BG-6) muss übermittelt
         werden.</c:description>
-      <c:description c:language="en">TBD</c:description>
+      <c:description c:language="en">The group “SELLER CONTACT” (BG-6) shall be provided.</c:description>
       <c:restrictions>
         <c:cardinality minOccurs="1">
           <c:term>BG-6</c:term>
@@ -93,7 +92,7 @@
     <c:rule id="BR-DE-3">
       <c:description c:language="de">Das Element „Seller city“ (BT-37) muss übermittelt
         werden.</c:description>
-      <c:description c:language="en">TBD</c:description>
+      <c:description c:language="en">The element “seller city” (BT-37) shall be provided.</c:description>
       <c:restrictions>
         <c:cardinality minOccurs="1">
           <c:term>BT-37</c:term>
@@ -105,7 +104,7 @@
     <c:rule id="BR-DE-4">
       <c:description c:language="de">Das Element „Seller post code“ (BT-38) muss übermittelt
         werden.</c:description>
-      <c:description c:language="en">TBD</c:description>
+      <c:description c:language="en">The element “Seller post code“ (BT-38) shall be provided.</c:description>
       <c:restrictions>
         <c:cardinality minOccurs="1">
           <c:term>BT-38</c:term>
@@ -116,7 +115,7 @@
     <c:rule id="BR-DE-5">
       <c:description c:language="de">Das Element „Seller contact point“ (BT-41) muss übermittelt
         werden.</c:description>
-      <c:description c:language="en">TBD</c:description>
+      <c:description c:language="en">The element “Seller contact point“ (BT-41) shall be provided.</c:description>
       <c:restrictions>
         <c:cardinality minOccurs="1">
           <c:term>BT-41</c:term>
@@ -127,7 +126,7 @@
     <c:rule id="BR-DE-6">
       <c:description c:language="de">Das Element „Seller contact telephone number“ (BT-42) muss
         übermittelt werden.</c:description>
-      <c:description c:language="en">TBD</c:description>
+      <c:description c:language="en">The element “Seller contact telephone number“ (BT-42) shall be provided.</c:description>
       <c:restrictions>
         <c:cardinality minOccurs="1">
           <c:term>BT-42</c:term>
@@ -138,7 +137,7 @@
     <c:rule id="BR-DE-7">
       <c:description c:language="de">Das Element „Seller contact email address“ (BT-43) muss
         übermittelt werden.</c:description>
-      <c:description c:language="en">TBD</c:description>
+      <c:description c:language="en">The element “Seller contact email address“ (BT-43) shall be provided.</c:description>
       <c:restrictions>
         <c:cardinality minOccurs="1">
           <c:term>BT-43</c:term>
@@ -149,7 +148,7 @@
     <c:rule id="BR-DE-8">
       <c:description c:language="de">Das Element „Buyer city“ (BT-52) muss übermittelt
         werden.</c:description>
-      <c:description c:language="en">TBD</c:description>
+      <c:description c:language="en">The element “Buyer city“ (BT-52) shall be provided.</c:description>
       <c:restrictions>
         <c:cardinality minOccurs="1">
           <c:term>BT-52</c:term>
@@ -160,7 +159,7 @@
     <c:rule id="BR-DE-9">
       <c:description c:language="de">Das Element „Buyer post code“ (BT-53) muss übermittelt
         werden.</c:description>
-      <c:description c:language="en">TBD</c:description>
+      <c:description c:language="en">The element “Buyer post code“ (BT-53) shall be provided.</c:description>
       <c:restrictions>
         <c:cardinality minOccurs="1">
           <c:term>BT-53</c:term>
@@ -171,7 +170,7 @@
     <c:rule id="BR-DE-10">
       <c:description c:language="de">Das Element „Deliver to city“ (BT-77) muss übermittelt
         werden.</c:description>
-      <c:description c:language="en">TBD</c:description>
+      <c:description c:language="en">The element “Deliver to city“ (BT-77) shall be provided.</c:description>
       <c:restrictions>
         <c:cardinality minOccurs="1">
           <c:term>BT-77</c:term>
@@ -193,7 +192,7 @@
     <c:rule id="BR-DE-12">
       <c:description c:language="de">Mit dem Element „Deliver to post code“ (BT-78) muss eine
         Postleitzahl übermittelt werden.</c:description>
-      <c:description c:language="en">TBD</c:description>
+      <c:description c:language="en">The element “Deliver to post code” (BT-78) shall contain a German postal code.</c:description>
       <c:restrictions>
         <c:cardinality minOccurs="1">
           <c:term>BT-78</c:term>
@@ -205,7 +204,7 @@
       <c:description c:language="de">In der Rechnung müssen Angaben zu einer der drei Gruppen
         „CREDIT TRANSFER“ (BG-17), „PAYMENT CARD INFORMATION“ (BG-18) oder „DIRECT DEBIT“ (BG-19)
         übermittelt werden.</c:description>
-      <c:description c:language="en">TBD</c:description>
+      <c:description c:language="en">An invoice shall contain information on „CREDIT TRANSFER“ (BG-17), „PAYMENT CARD INFORMATION“ (BG-18) or „DIRECT DEBIT“ (BG-19).</c:description>
       <c:restrictions>
         <c:other>
           <c:description>
@@ -220,7 +219,7 @@
     <c:rule id="BR-DE-14">
       <c:description c:language="de">Das Element „VAT category rate“ (BT-119) muss übermittelt
         werden.</c:description>
-      <c:description c:language="en">TBD</c:description>
+      <c:description c:language="en">The element “VAT category rate “ (BT-119) shall be provided.</c:description>
       <c:restrictions>
         <c:cardinality minOccurs="1">
           <c:term>BT-119</c:term>
@@ -231,7 +230,7 @@
     <c:rule id="BR-DE-15">
       <c:description c:language="de">Das Element „Buyer reference“ (BT-10) muss übermittelt
         werden.</c:description>
-      <c:description c:language="en">TBD</c:description>
+      <c:description c:language="en">The element “Buyer reference“ (BT-10) shall be provided.</c:description>
       <c:restrictions>
         <c:cardinality minOccurs="1">
           <c:term>BT-10</c:term>
@@ -243,7 +242,7 @@
       <c:description c:language="de">Das Element „Seller VAT identifier“ (BT-31) muss übermittelt
         werden, wenn nicht das Element „Seller tax registration identifier“ (BT-32) oder eine Gruppe
         „SELLER TAX REPRESENTATIVE PARTY“ (BG-11) übermittelt wurden.</c:description>
-      <c:description c:language="en">TBD</c:description>
+      <c:description c:language="en">The element “Seller VAT identifier“ (BT-31) shall be provided if the element “Seller tax registration identifier“ (BT-32) or the group “SELLER TAX REPRESENTATIVE PARTY“ (BG-11) is not provided.</c:description>
       <c:restrictions>
         <c:other>
           <c:description>
@@ -257,10 +256,10 @@
 
     <c:rule id="BR-DE-17">
       <c:description c:language="de">Mit dem Element „Invoice type code“ (BT-3) sollen
-        ausschließlich folgende Codes aus der Codeliste UNTDID 1001a übermittelt werden: 326
+        ausschließlich folgende Codes aus der Codeliste UNTDID 1001 übermittelt werden: 326
         (Partial invoice), 380 (Commercial invoice), 384 (Corrected invoice), 381 (Credit
         note)</c:description>
-      <c:description c:language="en">TBD</c:description>
+      <c:description c:language="en">The element “Invoice type code” (BT-3) should only contain the following values from code list UNTDID 1001: 326 (Partial invoice), 380 (Commercial invoice), 384 (Corrected invoice), 381 (Credit note)</c:description>
       <c:restrictions>
         <c:codelist>
           <c:term>BT-3</c:term>
@@ -279,7 +278,8 @@
         fälligen Betrags der Rechnung, ist der Grundwert zur Berechnung von Skonto oder Verzugszins
         als viertes Segment „BASISBETRAG=n“ mit dem semantischen Datentyp Amount
         anzugeben.</c:description>
-      <c:description c:language="en">TBD</c:description>
+      <c:description c:language="en">Information on cash discount for prompt payment (Skonto) or default charges (Verzugszinsen) shall be provided within the element “Payment terms” BT-20 in the following way (one row per entry): First segment “SKONTO” or “VERZUG”, second segment amount of days (“TAGE=N”), third segment percentage (“PROZENT=N”) with segments enfolded by #. Percentage shall be separated by dot with two decimal places. In case the base value of the invoiced amount is not provided in BT-115 but as partial amount, the base value shall be provided as fourth segment “BASISBETRAG=N” as semantic data type amount.
+</c:description>
       <c:restrictions>
         <c:other>
           <c:description>

--- a/examples/example-de-cius.xml
+++ b/examples/example-de-cius.xml
@@ -26,12 +26,15 @@
 
     <!-- Identifier as described in "7.6 Identification of core invoice usage specifications" -->
     <c:nameTechnical>urn:ce.eu:en16931:2017:xoev-de:kosit:standard:xrechnung_1.1</c:nameTechnical>
+    
+    <!-- Underlying Specification -->
+    <c:underlyingSpecification>urn:ce.eu:en16931:2017</c:underlyingSpecification>
 
     <!-- Version of CIUS/Extension -->
     <c:version>1.1</c:version>
 
-    <!-- Status of CIUS/Extension -->
-    <c:status>1.1</c:status>
+    <!-- The status of the specification (PLANNED, DEVELOPMENT, ACTIVE, REVOKED) -->
+    <c:status>Active</c:status>
 
     <!-- Date of publication of CIUS/Extension -->
     <c:date>2017-11-30</c:date>
@@ -42,7 +45,7 @@
     </c:publisher>
 
     <!-- Governor of extension -->
-    <c:governor>T-Planungsrat</c:governor>
+    <c:governor>IT-Planungsrat</c:governor>
 
     <!-- Country where CIUS/Extension is used -->
     <c:country>DE</c:country>
@@ -51,12 +54,15 @@
     <c:sector>Public Administration</c:sector>
 
     <!-- Contact email for sending inquiries -->
-    <c:email>kosit@finanzen.bremen.de</c:email>
+    <c:contact>kosit@finanzen.bremen.de</c:contact>
 
     <!-- Short description/purpose of spec -->
     <c:abstract>This CIUS-DE-NAT builds on top of the European Norm EN 16931-1:2017. All rules of
       the underlying specification apply with the addition of the rules stated in this
       document.</c:abstract>
+    
+    <!-- A hyperlink to more detailed information about the specification. Preferably that should include contact information. -->
+    <c:furtherInformation>https://www.xoev.de/de/xrechnung</c:furtherInformation>
   </c:metadata>
 
   <!-- desc can contain arbitrary HTML with human prose describing CIUS/Extension -->

--- a/examples/example-de-cius.xml
+++ b/examples/example-de-cius.xml
@@ -12,31 +12,34 @@
 
   -->
 <?xml-model href="../schema/ce-config.xsd"?>
-<c:config xmlns:c="urn:x-namespace:yet:to:be:determined"
-  xmlns:sch="http://purl.oclc.org/dsdl/schematron" xmlns="http://www.w3.org/1999/xhtml" type="true">
+<c:cius xmlns:c="urn:x-namespace:yet:to:be:determined"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:html="http://www.w3.org/1999/xhtml" type="false">
 
   <!-- meta element contains basic metainformation about CIUS/Extension -->
-  <c:meta>
+  <c:metadata>
     <!-- Common abbreviation used when referred to the CIUS/Extension -->
-    <c:name>CIUS-DE-NAT</c:name>
+    <c:nameShort>CIUS-DE-NAT</c:nameShort>
 
     <!-- Human readable name of CIUS/Extension -->
-    <c:title>Standard XRechnung Version XRechnung 1.1 | Fassung vom 30.11.2017</c:title>
+    <c:nameLong>Standard XRechnung Version XRechnung 1.1 | Fassung vom 30.11.2017</c:nameLong>
 
     <!-- Identifier as described in "7.6 Identification of core invoice usage specifications" -->
-    <c:id>urn:ce.eu:en16931:2017:xoev-de:kosit:standard:xrechnung_1.1</c:id>
+    <c:nameTechnical>urn:ce.eu:en16931:2017:xoev-de:kosit:standard:xrechnung_1.1</c:nameTechnical>
 
     <!-- Version of CIUS/Extension -->
     <c:version>1.1</c:version>
-
+    
+    <!-- Status of CIUS/Extension -->
+    <c:status>1.1</c:status>
+    
     <!-- Date of publication of CIUS/Extension -->
-    <c:date>2017-11-30</c:date>
+    <c:date>2017-11-30</c:date>   
 
     <!-- Author of extension, any HTML markup can be used inside element -->
-    <c:publisher> Koordinierungsstelle für IT-Standards, <a
-        href="mailto:kosit@finanzen.bremen.de">kosit@finanzen.bremen.de</a>
-    </c:publisher>
-
+    <c:publisher>Koordinierungsstelle für IT-Standards, <html:a
+      href="mailto:kosit@finanzen.bremen.de">kosit@finanzen.bremen.de</html:a>
+    </c:publisher>   
+ 
     <!-- Governor of extension -->
     <c:governor>T-Planungsrat</c:governor>
 
@@ -51,173 +54,186 @@
 
     <!-- Short description/purpose of spec -->
     <c:abstract>This CIUS-DE-NAT builds on top of the European Norm EN 16931-1:2017. All rules of the underlying specification apply with the addition of the rules stated in this document.</c:abstract>
-  </c:meta>
+  </c:metadata>
 
   <!-- desc can contain arbitrary HTML with human prose describing CIUS/Extension -->
-  <c:desc>
+  <c:description>Text <html:a language="de"></html:a>
     <!-- Empty in this example. -->
-  </c:desc>
+  </c:description>
 
-  <c:rules>
+  <c:business-rules> 
     <!-- The following set of rules are a technical representation of the set of rules given by the German CIUS XRechnung-->
-
-    <c:rule id="BR-DE-1">
-    	<c:desc xml:lang="de">Eine Rechnung (INVOICE) muss Angaben zu „PAYMENT INSTRUCTIONS“ (BG-16) enthalten.</c:desc>
-    	<c:desc xml:lang="en">An invoice (INVOICE) must contain information on „PAYMENT INSTRUCTIONS“ (BG-16).</c:desc>
-    	<c:cardinality minOccurs="1">
-    	  <c:term>BG-16</c:term>
-    	</c:cardinality>
+    <c:rule id="BR-DE-1" core-elements="BG-16">
+    	<c:description c:language="de">Eine Rechnung (INVOICE) muss Angaben zu „PAYMENT INSTRUCTIONS“ (BG-16) enthalten.</c:description>
+    	<c:description c:language="en">An invoice (INVOICE) must contain information on „PAYMENT INSTRUCTIONS“ (BG-16).</c:description>
+      <c:restrictions>
+        <c:cardinality minOccurs="1" />
+      </c:restrictions>
       </c:rule>
 
-    <c:rule id="BR-DE-2">
-    	<c:desc xml:lang="de">Die Gruppe „SELLER CONTACT“ (BG-6) muss übermittelt werden.</c:desc>
-    	<c:desc xml:lang="en">TBD</c:desc>
-      <c:cardinality minOccurs="1">
-        <c:term>BG-6</c:term>
-      </c:cardinality>
+    <c:rule id="BR-DE-2" core-elements="BG-16">
+      <c:description c:language="en">Die Gruppe „SELLER CONTACT“ (BG-6) muss übermittelt werden.</c:description>
+    	<c:description c:language="en">TBD</c:description>
+      <c:restrictions><c:cardinality minOccurs="1"/></c:restrictions>
     </c:rule>
 
-    <c:rule id="BR-DE-3">
-    	<c:desc xml:lang="de">Das Element „Seller city“ (BT-37) muss übermittelt werden.</c:desc>
-    	<c:desc xml:lang="en">TBD</c:desc>
-      <c:cardinality minOccurs="1">
-        <c:term>BT-37</c:term>
-      </c:cardinality>
+    <c:rule id="BR-DE-3" core-elements="BT-37">
+    	<c:description c:language="de">Das Element „Seller city“ (BT-37) muss übermittelt werden.</c:description>
+    	<c:description c:language="en">TBD</c:description>
+      <c:restrictions><c:cardinality minOccurs="1"/></c:restrictions>
+       
     </c:rule>
 
-    <c:rule id="BR-DE-4">
-    	<c:desc xml:lang="de">Das Element „Seller post code“ (BT-38) muss übermittelt werden.</c:desc>
-    	<c:desc xml:lang="en">TBD</c:desc>
-      <c:cardinality minOccurs="1">
-        <c:term>BT-38</c:term>
-      </c:cardinality>
+    <c:rule id="BR-DE-4" core-elements="BT-38">
+    	<c:description c:language="de">Das Element „Seller post code“ (BT-38) muss übermittelt werden.</c:description>
+    	<c:description c:language="en">TBD</c:description>
+      <c:restrictions>
+        <c:cardinality minOccurs="1"/>
+      </c:restrictions>
     </c:rule>
 
-    <c:rule id="BR-DE-5">
-    	<c:desc xml:lang="de">Das Element „Seller contact point“ (BT-41) muss übermittelt werden.</c:desc>
-    	<c:desc xml:lang="en">TBD</c:desc>
-      <c:cardinality minOccurs="1">
-        <c:term>BT-41</c:term>
-      </c:cardinality>
+    <c:rule id="BR-DE-5" core-elements="BT-41">
+    	<c:description c:language="de">Das Element „Seller contact point“ (BT-41) muss übermittelt werden.</c:description>
+    	<c:description c:language="en">TBD</c:description>
+      <c:restrictions>
+        <c:cardinality minOccurs="1"/>
+      </c:restrictions>
     </c:rule>
 
     <c:rule id="BR-DE-6">
-    	<c:desc xml:lang="de">Das Element „Seller contact telephone number“ (BT-42) muss übermittelt werden.</c:desc>
-    	<c:desc xml:lang="en">TBD</c:desc>
-      <c:cardinality minOccurs="1">
-        <c:term>BT-42</c:term>
-      </c:cardinality>
+    	<c:description c:language="de">Das Element „Seller contact telephone number“ (BT-42) muss übermittelt werden.</c:description>
+    	<c:description c:language="en">TBD</c:description>
+      <c:restrictions>
+        <c:cardinality minOccurs="1"/>
+      </c:restrictions>
     </c:rule>
 
-    <c:rule id="BR-DE-7">
-    	<c:desc xml:lang="de">Das Element „Seller contact email address“ (BT-43) muss übermittelt werden.</c:desc>
-    	<c:desc xml:lang="en">TBD</c:desc>
-      <c:cardinality minOccurs="1">
-        <c:term>BT-43</c:term>
-      </c:cardinality>
+    <c:rule id="BR-DE-7" core-elements="BT-43">
+    	<c:description c:language="de">Das Element „Seller contact email address“ (BT-43) muss übermittelt werden.</c:description>
+    	<c:description c:language="en">TBD</c:description>
+      <c:restrictions>
+        <c:cardinality minOccurs="1"/>
+      </c:restrictions>
     </c:rule>
 
-    <c:rule id="BR-DE-8">
-    	<c:desc xml:lang="de">Das Element „Buyer city“ (BT-52) muss übermittelt werden.</c:desc>
-    	<c:desc xml:lang="en">TBD</c:desc>
-      <c:cardinality minOccurs="1">
-        <c:term>BT-52</c:term>
-      </c:cardinality>
+    <c:rule id="BR-DE-8" core-elements="BT-52">
+    	<c:description c:language="de">Das Element „Buyer city“ (BT-52) muss übermittelt werden.</c:description>
+    	<c:description c:language="en">TBD</c:description>
+      <c:restrictions>
+        <c:cardinality minOccurs="1"/>
+      </c:restrictions>
     </c:rule>
 
-    <c:rule id="BR-DE-9">
-    	<c:desc xml:lang="de">Das Element „Buyer post code“ (BT-53) muss übermittelt werden.</c:desc>
-    	<c:desc xml:lang="en">TBD</c:desc>
-      <c:cardinality minOccurs="1">
-        <c:term>BT-53</c:term>
-      </c:cardinality>
+    <c:rule id="BR-DE-9" core-elements="BT-53">
+    	<c:description c:language="de">Das Element „Buyer post code“ (BT-53) muss übermittelt werden.</c:description>
+    	<c:description c:language="en">TBD</c:description>
+      <c:restrictions>
+        <c:cardinality minOccurs="1"/>
+      </c:restrictions>
     </c:rule>
 
-    <c:rule id="BR-DE-10">
-    	<c:desc xml:lang="de">Das Element „Deliver to city“ (BT-77) muss übermittelt werden.</c:desc>
-    	<c:desc xml:lang="en">TBD</c:desc>
-      <c:cardinality minOccurs="1">
-        <c:term>BT-77</c:term>
-      </c:cardinality>
+    <c:rule id="BR-DE-10" core-elements="BT-77">
+    	<c:description c:language="de">Das Element „Deliver to city“ (BT-77) muss übermittelt werden.</c:description>
+    	<c:description c:language="en">TBD</c:description>
+      <c:restrictions>
+        <c:cardinality minOccurs="1"/>
+      </c:restrictions>
     </c:rule>
     
-    <c:rule id="BR-DE-11">
-     	<c:desc xml:lang="de">Das Element „Deliver to post code“ (BT-78) muss übermittelt werden.</c:desc>
-    	<c:desc xml:lang="en">TBD</c:desc>
-      <c:cardinality minOccurs="1">
-        <c:term>BT-78</c:term>
-      </c:cardinality>
+    <c:rule id="BR-DE-11" core-elements="BT-78">
+     	<c:description c:language="de">Das Element „Deliver to post code“ (BT-78) muss übermittelt werden.</c:description>
+    	<c:description c:language="en">TBD</c:description>
+      <c:restrictions>
+        <c:cardinality minOccurs="1"/>
+      </c:restrictions>
     </c:rule>
 
-    <c:rule id="BR-DE-12">
-    	<c:desc xml:lang="de">Mit dem Element „Deliver to post code“ (BT-78) muss eine Postleitzahl übermittelt werden.</c:desc>
-    	<c:desc xml:lang="en">TBD</c:desc>
-      <c:cardinality minOccurs="1">
-        <c:term>BT-78</c:term>
-      </c:cardinality>
+    <c:rule id="BR-DE-12" core-elements="BT-78">
+    	<c:description c:language="de">Mit dem Element „Deliver to post code“ (BT-78) muss eine Postleitzahl übermittelt werden.</c:description>
+    	<c:description c:language="en">TBD</c:description>
+      <c:restrictions>
+        <c:cardinality minOccurs="1"/>
+      </c:restrictions>
     </c:rule>
 
     <c:rule id="BR-DE-13">
-    	<c:desc xml:lang="de">In der Rechnung müssen Angaben zu einer der drei Gruppen „CREDIT TRANSFER“ (BG-17), „PAYMENT CARD INFORMATION“ (BG-18) oder „DIRECT DEBIT“ (BG-19) übermittelt werden.</c:desc>
-    	<c:desc xml:lang="en">TBD</c:desc>
-      <c:other>
-        <c:term>BG-17</c:term>
-        <c:term>BG-18</c:term>
-        <c:term>BG-19</c:term>
-      </c:other>
+    	<c:description c:language="de">In der Rechnung müssen Angaben zu einer der drei Gruppen „CREDIT TRANSFER“ (BG-17), „PAYMENT CARD INFORMATION“ (BG-18) oder „DIRECT DEBIT“ (BG-19) übermittelt werden.</c:description>
+    	<c:description c:language="en">TBD</c:description>
+      <c:restrictions>
+        <c:other> 
+          <c:description>
+            <c:term>BG-17</c:term> 
+            <c:term>BG-18</c:term>
+            <c:term>BG-19</c:term>
+          </c:description>
+          
+        </c:other>  
+      </c:restrictions>
+      
     </c:rule>
 
-    <c:rule id="BR-DE-14">
-    	<c:desc xml:lang="de">Das Element „VAT category rate“ (BT-119) muss übermittelt werden.</c:desc>
-    	<c:desc xml:lang="en">TBD</c:desc>
-      <c:cardinality minOccurs="1">
-        <c:term>BT-119</c:term>
-      </c:cardinality>
+    <c:rule id="BR-DE-14" core-elements="BT-119">
+    	<c:description c:language="de">Das Element „VAT category rate“ (BT-119) muss übermittelt werden.</c:description>
+    	<c:description c:language="en">TBD</c:description>
+      <c:restrictions>
+        <c:cardinality minOccurs="1"/>
+      </c:restrictions>
     </c:rule>
 
-    <c:rule id="BR-DE-15">
-    	<c:desc xml:lang="de">Das Element „Buyer reference“ (BT-10) muss übermittelt werden.</c:desc>
-    	<c:desc xml:lang="en">TBD</c:desc>
-      <c:cardinality minOccurs="1">
-        <c:term>BT-10</c:term>
-      </c:cardinality>
+    <c:rule id="BR-DE-15" core-elements="BT-10">
+    	<c:description c:language="de">Das Element „Buyer reference“ (BT-10) muss übermittelt werden.</c:description>
+    	<c:description c:language="en">TBD</c:description>
+      <c:restrictions>
+        <c:cardinality minOccurs="1"/>
+      </c:restrictions>
     </c:rule>
 
-    <c:rule id="BR-DE-16">
-    	<c:desc xml:lang="de">Das Element „Seller VAT identifier“ (BT-31) muss übermittelt werden, wenn nicht das Element „Seller tax registration identifier“ (BT-32) oder eine Gruppe „SELLER TAX REPRESENTATIVE PARTY“ (BG-11) übermittelt wurden.</c:desc>
-    	<c:desc xml:lang="en">TBD</c:desc>
-      <c:other>
-        <c:term>BT-31</c:term>
-        <c:term>BT-32</c:term>
-        <c:term>BG-11</c:term>
-      </c:other>
+    <c:rule id="BR-DE-16" core-elements="BT-31 BT-32 BG-11">
+    	<c:description c:language="de">Das Element „Seller VAT identifier“ (BT-31) muss übermittelt werden, wenn nicht das Element „Seller tax registration identifier“ (BT-32) oder eine Gruppe „SELLER TAX REPRESENTATIVE PARTY“ (BG-11) übermittelt wurden.</c:description>
+    	<c:description c:language="en">TBD</c:description>
+      <c:restrictions>
+        <c:other>
+          <c:description>
+            <c:term>BT-31</c:term>
+            <c:term>BT-32</c:term>
+            <c:term>BG-11</c:term>
+          </c:description>
+        </c:other>
+      </c:restrictions>
+       </c:rule>
+
+    <c:rule id="BR-DE-17" core-elements="BT-3">
+    	<c:description c:language="de">Mit dem Element „Invoice type code“ (BT-3) sollen ausschließlich folgende Codes aus der Codeliste UNTDID 1001a übermittelt werden: 326 (Partial invoice), 380 (Commercial invoice), 384 (Corrected invoice), 381 (Credit note)</c:description>
+    	<c:description c:language="en">TBD</c:description>
+      <c:restrictions>
+        <c:codelist>
+          <c:allowed-codes>326 380 384 381</c:allowed-codes>
+        </c:codelist>
+      </c:restrictions>
     </c:rule>
 
-    <c:rule id="BR-DE-17">
-    	<c:desc xml:lang="de">Mit dem Element „Invoice type code“ (BT-3) sollen ausschließlich folgende Codes aus der Codeliste UNTDID 1001a übermittelt werden: 326 (Partial invoice), 380 (Commercial invoice), 384 (Corrected invoice), 381 (Credit note)</c:desc>
-    	<c:desc xml:lang="en">TBD</c:desc>
-      <c:codelist>
-        <c:term>BT-3</c:term>
-        <c:value>326</c:value>
-        <c:value>380</c:value>
-        <c:value>384</c:value>
-        <c:value>381</c:value>
-      </c:codelist>
-    </c:rule>
-
-    <c:rule id="BR-DE-18">
-    	<c:desc xml:lang="de">Informationen zur Gewährung von Skonto oder zur Berechnung von Verzugszinsen müssen wie folgt im Element „Payment terms“ (BT-20) jeweils in einer eigenen Zeile übermittelt werden: Anzugeben ist im ersten Segment „SKONTO“ oder „VERZUG“, im zweiten „TAGE=n“, im dritten „PROZENT=n“, wobei die Segmente jeweils von einer „#“ umfasst sind. Prozentzahlen sind mit Punkt getrennt von zwei Nachkommastellen anzugeben. Liegt dem zu berechnenden Betrag nicht BT-115, „fälliger Betrag“ zugrunde, sondern nur ein Teil des fälligen Betrags der Rechnung, ist der Grundwert zur Berechnung von Skonto oder Verzugszins als viertes Segment „BASISBETRAG=n“ mit dem semantischen Datentyp Amount anzugeben.</c:desc>
-    	<c:desc xml:lang="en">TBD</c:desc>
-      <c:other>
-        <c:term>BT-20</c:term>
-        <c:term>BT-115</c:term>
-      </c:other>
+    <c:rule id="BR-DE-18" core-elements="BT-20 BT-115">
+    	<c:description c:language="de">Informationen zur Gewährung von Skonto oder zur Berechnung von Verzugszinsen müssen wie folgt im Element „Payment terms“ (BT-20) jeweils in einer eigenen Zeile übermittelt werden: Anzugeben ist im ersten Segment „SKONTO“ oder „VERZUG“, im zweiten „TAGE=n“, im dritten „PROZENT=n“, wobei die Segmente jeweils von einer „#“ umfasst sind. Prozentzahlen sind mit Punkt getrennt von zwei Nachkommastellen anzugeben. Liegt dem zu berechnenden Betrag nicht BT-115, „fälliger Betrag“ zugrunde, sondern nur ein Teil des fälligen Betrags der Rechnung, ist der Grundwert zur Berechnung von Skonto oder Verzugszins als viertes Segment „BASISBETRAG=n“ mit dem semantischen Datentyp Amount anzugeben.</c:description>
+    	<c:description c:language="en">TBD</c:description>
+      <c:restrictions>
+        <c:other>
+          <c:description>
+            <c:term>BT-20</c:term>
+            <c:term>BT-115</c:term>
+          </c:description>
+        </c:other>
+      </c:restrictions>
     </c:rule>
 
     <c:rule id="BR-DE-19">
-      <c:desc>The size of all attached documents together may not exceed 15MB</c:desc>
-      <c:technical/>
+      <c:description>The size of all attached documents together may not exceed 15MB</c:description>
+      <c:restrictions>
+        <c:other>
+          <c:description><type>technical</type></c:description>
+        </c:other>
+      </c:restrictions>
     </c:rule>
-  </c:rules>
+    
+  </c:business-rules>
 
-</c:config>
+</c:cius>

--- a/examples/example-de-cius.xml
+++ b/examples/example-de-cius.xml
@@ -14,7 +14,7 @@
 <?xml-model href="../schema/ce-config.xsd"?>
 <c:cius xmlns:c="urn:x-namespace:yet:to:be:determined"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xmlns:html="http://www.w3.org/1999/xhtml" type="false">
+  xmlns:html="http://www.w3.org/1999/xhtml" >
 
   <!-- meta element contains basic metainformation about CIUS/Extension -->
   <c:metadata>
@@ -72,155 +72,130 @@
 
   <!-- The following set of rules are a technical representation of the set of rules given by the German CIUS XRechnung-->
   <c:business-rules>
-    <c:rule id="BR-DE-1" >
+    <c:rule id="BR-DE-1" cius-specific="true">
       <c:description xml:lang="de">Eine Rechnung (INVOICE) muss Angaben zu
         „PAYMENT INSTRUCTIONS“ (BG-16) enthalten.</c:description>
       <c:description xml:lang="en">The INVOICE shall contain information on
         PAYMENT INSTRUCTIONS (BG-16).</c:description>
       <c:restrictions>
-        <c:cardinality minOccurs="1">
-          <c:term>BG-16</c:term>
-        </c:cardinality>
+        <c:cardinality minOccurs="1" term="BG-16"/>        
 
       </c:restrictions>
     </c:rule>
 
-    <c:rule id="BR-DE-2">
+    <c:rule id="BR-DE-2" cius-specific="true">
       <c:description xml:lang="en">Die Gruppe „SELLER CONTACT“ (BG-6) muss
         übermittelt werden.</c:description>
       <c:description xml:lang="en">The group SELLER CONTACT1 (BG-6) shall be
         transmitted.</c:description>
       <c:restrictions>
-        <c:cardinality minOccurs="1">
-          <c:term>BG-6</c:term>
-        </c:cardinality>
-
+        <c:cardinality minOccurs="1" term="BG-6"/>
       </c:restrictions>
     </c:rule>
 
-    <c:rule id="BR-DE-3">
+    <c:rule id="BR-DE-3" cius-specific="true">
       <c:description xml:lang="de">Das Element „Seller city“ (BT-37) muss
         übermittelt werden.</c:description>
       <c:description xml:lang="en">The element “Seller city” (BT-37) shall be
         transmitted.</c:description>
       <c:restrictions>
-        <c:cardinality minOccurs="1">
-          <c:term>BT-37</c:term>
-        </c:cardinality>
+        <c:cardinality minOccurs="1" term="BT-37"/>
       </c:restrictions>
 
     </c:rule>
 
-    <c:rule id="BR-DE-4">
+    <c:rule id="BR-DE-4" cius-specific="true">
       <c:description xml:lang="de">Das Element „Seller post code“ (BT-38) muss
         übermittelt werden.</c:description>
       <c:description xml:lang="en">The element “Seller post code” (BT-38) shall
         be transmitted.</c:description>
       <c:restrictions>
-        <c:cardinality minOccurs="1">
-          <c:term>BT-38</c:term>
-        </c:cardinality>
+        <c:cardinality minOccurs="1" term="BT-38"/>
       </c:restrictions>
     </c:rule>
 
-    <c:rule id="BR-DE-5">
+    <c:rule id="BR-DE-5" cius-specific="true">
       <c:description xml:lang="de">Das Element „Seller contact point“ (BT-41)
         muss übermittelt werden.</c:description>
       <c:description xml:lang="en">The element “Seller contact point” (BT-41)
         shall be transmitted.</c:description>
       <c:restrictions>
-        <c:cardinality minOccurs="1">
-          <c:term>BT-41</c:term>
-        </c:cardinality>
+        <c:cardinality minOccurs="1" term="BT-41"/>
       </c:restrictions>
     </c:rule>
 
-    <c:rule id="BR-DE-6">
+    <c:rule id="BR-DE-6" cius-specific="true">
       <c:description xml:lang="de">Das Element „Seller contact telephone number“
         (BT-42) muss übermittelt werden.</c:description>
       <c:description xml:lang="en">The element „Seller contact telephone
         number“(BT-BT) shall be transmitted.</c:description>
       <c:restrictions>
-        <c:cardinality minOccurs="1">
-          <c:term>BT-42</c:term>
-        </c:cardinality>
+        <c:cardinality minOccurs="1" term="BT-42"/>
       </c:restrictions>
     </c:rule>
 
-    <c:rule id="BR-DE-7">
+    <c:rule id="BR-DE-7" cius-specific="true">
       <c:description xml:lang="de">Das Element „Seller contact email address“
         (BT-43) muss übermittelt werden.</c:description>
       <c:description xml:lang="en">The element “Seller contact email address”
         (BT-43) shall be transmitted.</c:description>
       <c:restrictions>
-        <c:cardinality minOccurs="1">
-          <c:term>BT-43</c:term>
-        </c:cardinality>
+        <c:cardinality minOccurs="1" term="BT-43"/>
       </c:restrictions>
     </c:rule>
 
-    <c:rule id="BR-DE-8">
+    <c:rule id="BR-DE-8" cius-specific="true">
       <c:description xml:lang="de">Das Element „Buyer city“ (BT-52) muss
         übermittelt werden.</c:description>
       <c:description xml:lang="en">The element “Buyer city” (BT-52) shall be
         transmitted.</c:description>
       <c:restrictions>
-        <c:cardinality minOccurs="1">
-          <c:term>BT-52</c:term>
-        </c:cardinality>
+        <c:cardinality minOccurs="1" term="BT-52"/>
       </c:restrictions>
     </c:rule>
 
-    <c:rule id="BR-DE-9">
+    <c:rule id="BR-DE-9" cius-specific="true">
       <c:description xml:lang="de">Das Element „Buyer post code“ (BT-53) muss
         übermittelt werden.</c:description>
       <c:description xml:lang="en">The element “Buyer post code” (BT-53) shall
         be transmitted.</c:description>
       <c:restrictions>
-        <c:cardinality minOccurs="1">
-          <c:term>BT-53</c:term>
-        </c:cardinality>
+        <c:cardinality minOccurs="1" term="BT-53"/>
       </c:restrictions>
     </c:rule>
 
-    <c:rule id="BR-DE-10">
+    <c:rule id="BR-DE-10" cius-specific="true">
       <c:description xml:lang="de">Das Element „Deliver to city“ (BT-77) muss
         übermittelt werden.</c:description>
       <c:description xml:lang="en">The element “Deliver to city“” (BT-77) shall
         be transmitted.</c:description>
       <c:restrictions>
-        <c:cardinality minOccurs="1">
-          <c:term>BT-77</c:term>
-        </c:cardinality>
+        <c:cardinality minOccurs="1" term="BT-77"/>
       </c:restrictions>
     </c:rule>
 
-    <c:rule id="BR-DE-11">
+    <c:rule id="BR-DE-11" cius-specific="true">
       <c:description xml:lang="de">Das Element „Deliver to post code“ (BT-78)
         muss übermittelt werden.</c:description>
       <c:description xml:lang="en">The element “Deliver to post code” (BT-78)
         shall be transmitted.</c:description>
 
       <c:restrictions>
-        <c:cardinality minOccurs="1">
-          <c:term>BT-78</c:term>
-        </c:cardinality>
+        <c:cardinality minOccurs="1" term="BT-78"/>        
       </c:restrictions>
     </c:rule>
 
-    <c:rule id="BR-DE-12">
+    <c:rule id="BR-DE-12" cius-specific="true">
       <c:description xml:lang="de">Mit dem Element „Deliver to post code“
         (BT-78) muss eine Postleitzahl übermittelt werden.</c:description>
       <c:description xml:lang="en">A post code shall be transmitted together
         with the element “Deliver to post code” (BT-78).</c:description>
       <c:restrictions>
-        <c:cardinality minOccurs="1">
-          <c:term>BT-78</c:term>
-        </c:cardinality>
+        <c:cardinality minOccurs="1" term="BT-78"/>
       </c:restrictions>
     </c:rule>
 
-    <c:rule id="BR-DE-13">
+    <c:rule id="BR-DE-13" cius-specific="true">
       <c:description xml:lang="de">In der Rechnung müssen Angaben zu einer der
         drei Gruppen „CREDIT TRANSFER“ (BG-17), „PAYMENT CARD INFORMATION“
         (BG-18) oder „DIRECT DEBIT“ (BG-19) übermittelt werden.</c:description>
@@ -240,31 +215,27 @@
 
     </c:rule>
 
-    <c:rule id="BR-DE-14">
+    <c:rule id="BR-DE-14" cius-specific="true">
       <c:description xml:lang="de">Das Element „VAT category rate“ (BT-119) muss
         übermittelt werden.</c:description>
       <c:description xml:lang="en">The element “VAT category rate” (BT-119)
         shall be transmitted.</c:description>
       <c:restrictions>
-        <c:cardinality minOccurs="1">
-          <c:term>BT-119</c:term>
-        </c:cardinality>
+        <c:cardinality minOccurs="1" term="BT-119"/>
       </c:restrictions>
     </c:rule>
 
-    <c:rule id="BR-DE-15">
+    <c:rule id="BR-DE-15" cius-specific="true">
       <c:description xml:lang="de">Das Element „Buyer reference“ (BT-10) muss
         übermittelt werden.</c:description>
       <c:description xml:lang="en">The element „Buyer reference“ (BT-10) shall
         be transmitted.</c:description>
       <c:restrictions>
-        <c:cardinality minOccurs="1">
-          <c:term>BT-10</c:term>
-        </c:cardinality>
+        <c:cardinality minOccurs="1" term="BT-10"/>
       </c:restrictions>
     </c:rule>
 
-    <c:rule id="BR-DE-16">
+    <c:rule id="BR-DE-16" cius-specific="true">
       <c:description xml:lang="de">Das Element „Seller VAT identifier“ (BT-31)
         muss übermittelt werden, wenn nicht das Element „Seller tax registration
         identifier“ (BT-32) oder eine Gruppe „SELLER TAX REPRESENTATIVE PARTY“
@@ -284,7 +255,7 @@
       </c:restrictions>
     </c:rule>
 
-    <c:rule id="BR-DE-17" core-elements="BT-3" c:cius-specific="true">
+    <c:rule id="BR-DE-17" core-elements="BT-3" cius-specific="true">
       <c:description xml:lang="de">Mit dem Element „Invoice type code“ (BT-3)
         sollen ausschließlich folgende Codes aus der Codeliste UNTDID 1001
         übermittelt werden: 326 (Partial invoice), 380 (Commercial invoice), 384
@@ -300,7 +271,7 @@
       </c:restrictions>
     </c:rule>
 
-    <c:rule id="BR-DE-18">
+    <c:rule id="BR-DE-18" cius-specific="true">
       <c:description xml:lang="de">Informationen zur Gewährung von Skonto oder
         zur Berechnung von Verzugszinsen müssen wie folgt im Element „Payment
         terms“ (BT-20) jeweils in einer eigenen Zeile übermittelt werden:
@@ -334,7 +305,7 @@
     </c:rule>
 
     <!-- Example of a general rule not specific to BT or BG -->
-    <c:rule id="BR-DE-19">
+    <c:rule id="BR-DE-19" cius-specific="true">
       <c:description xml:lang="en">The size of all attached documents together
         may not exceed 15MB</c:description>
       <c:restrictions>

--- a/examples/example-de-cius.xml
+++ b/examples/example-de-cius.xml
@@ -58,7 +58,7 @@
     <c:contact>kosit@finanzen.bremen.de</c:contact>
 
     <!-- Short description/purpose of spec -->
-    <c:abstract>This CIUS-DE-NAT builds on top of the European Norm EN 16931-1:2017. All rules of
+    <c:abstract xml:lang="en">This CIUS-DE-NAT builds on top of the European Norm EN 16931-1:2017. All rules of
       the underlying specification apply with the addition of the rules stated in this
       document.</c:abstract>
     

--- a/examples/example-de-cius.xml
+++ b/examples/example-de-cius.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-  This is very rough and sketchy proposal for machine readable format
+  This is a proposal for machine readable format
   for describing CIUS and/or Extensions to core EU invoice
 
   In this example German National CIUS (XRechnung) is shown using proposed syntax
@@ -22,7 +22,7 @@
     <c:nameShort>CIUS-DE-NAT</c:nameShort>
 
     <!-- Human readable name of CIUS/Extension -->
-    <c:nameLong>Standard XRechnung Version XRechnung 1.1 | Fassung vom 30.11.2017</c:nameLong>
+    <c:nameLong>Standard XRechnung</c:nameLong>
 
     <!-- Identifier as described in "7.6 Identification of core invoice usage specifications" -->
     <c:nameTechnical>urn:ce.eu:en16931:2017:xoev-de:kosit:standard:xrechnung_1.1</c:nameTechnical>
@@ -34,7 +34,7 @@
     <c:version>1.1</c:version>
 
     <!-- The status of the specification (PLANNED, DEVELOPMENT, ACTIVE, REVOKED) -->
-    <c:status>Active</c:status>
+    <c:status>active</c:status>
 
     <!-- Date of publication of CIUS/Extension -->
     <c:date>2017-11-30</c:date>
@@ -65,29 +65,30 @@
     <!-- A hyperlink to more detailed information about the specification. Preferably that should include contact information. -->
     <c:furtherInformation>https://www.xoev.de/de/xrechnung</c:furtherInformation>
   </c:metadata>
-
+ 
   <!-- desc can contain arbitrary HTML with human prose describing CIUS/Extension -->
-  <c:description>Text <html:a language="de"/>
+  <c:description xml:lang="en">Text with<html:b >HTML</html:b> content
     <!-- Empty in this example. -->
   </c:description>
 
   <c:business-rules>
     <!-- The following set of rules are a technical representation of the set of rules given by the German CIUS XRechnung-->
     <c:rule id="BR-DE-1">
-      <c:description c:language="de">Eine Rechnung (INVOICE) muss Angaben zu „PAYMENT INSTRUCTIONS“
+      <c:description xml:lang="de">Eine Rechnung (INVOICE) muss Angaben zu „PAYMENT INSTRUCTIONS“
         (BG-16) enthalten.</c:description>
-      <c:description c:language="en">An invoice shall contain information on “PAYMENT INTSTRUCTIONS” (BG-16).</c:description>
+      <c:description xml:lang="en">An invoice shall contain information on “PAYMENT INTSTRUCTIONS” (BG-16).</c:description>
       <c:restrictions>
         <c:cardinality minOccurs="1">
           <c:term>BG-16</c:term>
         </c:cardinality>
+        
       </c:restrictions>
     </c:rule>
 
     <c:rule id="BR-DE-2">
-      <c:description c:language="en">Die Gruppe „SELLER CONTACT“ (BG-6) muss übermittelt
+      <c:description xml:lang="en">Die Gruppe „SELLER CONTACT“ (BG-6) muss übermittelt
         werden.</c:description>
-      <c:description c:language="en">The group “SELLER CONTACT” (BG-6) shall be provided.</c:description>
+      <c:description xml:lang="en">The group “SELLER CONTACT” (BG-6) shall be provided.</c:description>
       <c:restrictions>
         <c:cardinality minOccurs="1">
           <c:term>BG-6</c:term>
@@ -97,9 +98,9 @@
     </c:rule>
 
     <c:rule id="BR-DE-3">
-      <c:description c:language="de">Das Element „Seller city“ (BT-37) muss übermittelt
+      <c:description xml:lang="de">Das Element „Seller city“ (BT-37) muss übermittelt
         werden.</c:description>
-      <c:description c:language="en">The element “seller city” (BT-37) shall be provided.</c:description>
+      <c:description xml:lang="en">The element “seller city” (BT-37) shall be provided.</c:description>
       <c:restrictions>
         <c:cardinality minOccurs="1">
           <c:term>BT-37</c:term>
@@ -109,9 +110,9 @@
     </c:rule>
 
     <c:rule id="BR-DE-4">
-      <c:description c:language="de">Das Element „Seller post code“ (BT-38) muss übermittelt
+      <c:description xml:lang="de">Das Element „Seller post code“ (BT-38) muss übermittelt
         werden.</c:description>
-      <c:description c:language="en">The element “Seller post code“ (BT-38) shall be provided.</c:description>
+      <c:description xml:lang="en">The element “Seller post code“ (BT-38) shall be provided.</c:description>
       <c:restrictions>
         <c:cardinality minOccurs="1">
           <c:term>BT-38</c:term>
@@ -120,9 +121,9 @@
     </c:rule>
 
     <c:rule id="BR-DE-5">
-      <c:description c:language="de">Das Element „Seller contact point“ (BT-41) muss übermittelt
+      <c:description xml:lang="de">Das Element „Seller contact point“ (BT-41) muss übermittelt
         werden.</c:description>
-      <c:description c:language="en">The element “Seller contact point“ (BT-41) shall be provided.</c:description>
+      <c:description xml:lang="en">The element “Seller contact point“ (BT-41) shall be provided.</c:description>
       <c:restrictions>
         <c:cardinality minOccurs="1">
           <c:term>BT-41</c:term>
@@ -131,9 +132,9 @@
     </c:rule>
 
     <c:rule id="BR-DE-6">
-      <c:description c:language="de">Das Element „Seller contact telephone number“ (BT-42) muss
+      <c:description xml:lang="de">Das Element „Seller contact telephone number“ (BT-42) muss
         übermittelt werden.</c:description>
-      <c:description c:language="en">The element “Seller contact telephone number“ (BT-42) shall be provided.</c:description>
+      <c:description xml:lang="en">The element “Seller contact telephone number“ (BT-42) shall be provided.</c:description>
       <c:restrictions>
         <c:cardinality minOccurs="1">
           <c:term>BT-42</c:term>
@@ -142,9 +143,9 @@
     </c:rule>
 
     <c:rule id="BR-DE-7">
-      <c:description c:language="de">Das Element „Seller contact email address“ (BT-43) muss
+      <c:description xml:lang="de">Das Element „Seller contact email address“ (BT-43) muss
         übermittelt werden.</c:description>
-      <c:description c:language="en">The element “Seller contact email address“ (BT-43) shall be provided.</c:description>
+      <c:description xml:lang="en">The element “Seller contact email address“ (BT-43) shall be provided.</c:description>
       <c:restrictions>
         <c:cardinality minOccurs="1">
           <c:term>BT-43</c:term>
@@ -153,9 +154,9 @@
     </c:rule>
 
     <c:rule id="BR-DE-8">
-      <c:description c:language="de">Das Element „Buyer city“ (BT-52) muss übermittelt
+      <c:description xml:lang="de">Das Element „Buyer city“ (BT-52) muss übermittelt
         werden.</c:description>
-      <c:description c:language="en">The element “Buyer city“ (BT-52) shall be provided.</c:description>
+      <c:description xml:lang="en">The element “Buyer city“ (BT-52) shall be provided.</c:description>
       <c:restrictions>
         <c:cardinality minOccurs="1">
           <c:term>BT-52</c:term>
@@ -164,9 +165,9 @@
     </c:rule>
 
     <c:rule id="BR-DE-9">
-      <c:description c:language="de">Das Element „Buyer post code“ (BT-53) muss übermittelt
+      <c:description xml:lang="de">Das Element „Buyer post code“ (BT-53) muss übermittelt
         werden.</c:description>
-      <c:description c:language="en">The element “Buyer post code“ (BT-53) shall be provided.</c:description>
+      <c:description xml:lang="en">The element “Buyer post code“ (BT-53) shall be provided.</c:description>
       <c:restrictions>
         <c:cardinality minOccurs="1">
           <c:term>BT-53</c:term>
@@ -175,9 +176,9 @@
     </c:rule>
 
     <c:rule id="BR-DE-10">
-      <c:description c:language="de">Das Element „Deliver to city“ (BT-77) muss übermittelt
+      <c:description xml:lang="de">Das Element „Deliver to city“ (BT-77) muss übermittelt
         werden.</c:description>
-      <c:description c:language="en">The element “Deliver to city“ (BT-77) shall be provided.</c:description>
+      <c:description xml:lang="en">The element “Deliver to city“ (BT-77) shall be provided.</c:description>
       <c:restrictions>
         <c:cardinality minOccurs="1">
           <c:term>BT-77</c:term>
@@ -186,9 +187,9 @@
     </c:rule>
 
     <c:rule id="BR-DE-11">
-      <c:description c:language="de">Das Element „Deliver to post code“ (BT-78) muss übermittelt
+      <c:description xml:lang="de">Das Element „Deliver to post code“ (BT-78) muss übermittelt
         werden.</c:description>
-      <c:description c:language="en">TBD</c:description>
+      <c:description xml:lang="en">TBD</c:description>
 
       <c:restrictions>
         <c:cardinality minOccurs="1">
@@ -197,10 +198,10 @@
       </c:restrictions>
     </c:rule>
 
-    <c:rule id="BR-DE-12">
-      <c:description c:language="de">Mit dem Element „Deliver to post code“ (BT-78) muss eine
+    <c:rule id="BR-DE-12" >
+      <c:description xml:lang="de">Mit dem Element „Deliver to post code“ (BT-78) muss eine
         Postleitzahl übermittelt werden.</c:description>
-      <c:description c:language="en">The element “Deliver to post code” (BT-78) shall contain a German postal code.</c:description>
+      <c:description xml:lang="en">The element “Deliver to post code” (BT-78) shall contain a German postal code.</c:description>
       <c:restrictions>
         <c:cardinality minOccurs="1">
           <c:term>BT-78</c:term>
@@ -209,10 +210,10 @@
     </c:rule>
 
     <c:rule id="BR-DE-13">
-      <c:description c:language="de">In der Rechnung müssen Angaben zu einer der drei Gruppen
+      <c:description xml:lang="de">In der Rechnung müssen Angaben zu einer der drei Gruppen
         „CREDIT TRANSFER“ (BG-17), „PAYMENT CARD INFORMATION“ (BG-18) oder „DIRECT DEBIT“ (BG-19)
         übermittelt werden.</c:description>
-      <c:description c:language="en">An invoice shall contain information on „CREDIT TRANSFER“ (BG-17), „PAYMENT CARD INFORMATION“ (BG-18) or „DIRECT DEBIT“ (BG-19).</c:description>
+      <c:description xml:lang="en">An invoice shall contain information on „CREDIT TRANSFER“ (BG-17), „PAYMENT CARD INFORMATION“ (BG-18) or „DIRECT DEBIT“ (BG-19).</c:description>
       <c:restrictions>
         <c:other>
           <c:description>
@@ -227,9 +228,9 @@
     </c:rule>
 
     <c:rule id="BR-DE-14">
-      <c:description c:language="de">Das Element „VAT category rate“ (BT-119) muss übermittelt
+      <c:description xml:lang="de">Das Element „VAT category rate“ (BT-119) muss übermittelt
         werden.</c:description>
-      <c:description c:language="en">The element “VAT category rate “ (BT-119) shall be provided.</c:description>
+      <c:description xml:lang="en">The element “VAT category rate “ (BT-119) shall be provided.</c:description>
       <c:restrictions>
         <c:cardinality minOccurs="1">
           <c:term>BT-119</c:term>
@@ -238,9 +239,9 @@
     </c:rule>
 
     <c:rule id="BR-DE-15">
-      <c:description c:language="de">Das Element „Buyer reference“ (BT-10) muss übermittelt
+      <c:description xml:lang="de">Das Element „Buyer reference“ (BT-10) muss übermittelt
         werden.</c:description>
-      <c:description c:language="en">The element “Buyer reference“ (BT-10) shall be provided.</c:description>
+      <c:description xml:lang="en">The element “Buyer reference“ (BT-10) shall be provided.</c:description>
       <c:restrictions>
         <c:cardinality minOccurs="1">
           <c:term>BT-10</c:term>
@@ -249,10 +250,10 @@
     </c:rule>
 
     <c:rule id="BR-DE-16">
-      <c:description c:language="de">Das Element „Seller VAT identifier“ (BT-31) muss übermittelt
+      <c:description xml:lang="de">Das Element „Seller VAT identifier“ (BT-31) muss übermittelt
         werden, wenn nicht das Element „Seller tax registration identifier“ (BT-32) oder eine Gruppe
         „SELLER TAX REPRESENTATIVE PARTY“ (BG-11) übermittelt wurden.</c:description>
-      <c:description c:language="en">The element “Seller VAT identifier“ (BT-31) shall be provided if the element “Seller tax registration identifier“ (BT-32) or the group “SELLER TAX REPRESENTATIVE PARTY“ (BG-11) is not provided.</c:description>
+      <c:description xml:lang="en">The element “Seller VAT identifier“ (BT-31) shall be provided if the element “Seller tax registration identifier“ (BT-32) or the group “SELLER TAX REPRESENTATIVE PARTY“ (BG-11) is not provided.</c:description>
       <c:restrictions>
         <c:other>
           <c:description>
@@ -265,11 +266,11 @@
     </c:rule>
 
     <c:rule id="BR-DE-17" core-elements="BT-3" c:cius-specific="true">
-      <c:description c:language="de">Mit dem Element „Invoice type code“ (BT-3) sollen
+      <c:description xml:lang="de">Mit dem Element „Invoice type code“ (BT-3) sollen
         ausschließlich folgende Codes aus der Codeliste UNTDID 1001 übermittelt werden: 326
         (Partial invoice), 380 (Commercial invoice), 384 (Corrected invoice), 381 (Credit
         note)</c:description>
-      <c:description c:language="en">The element “Invoice type code” (BT-3) should only contain the following values from code list UNTDID 1001: 326 (Partial invoice), 380 (Commercial invoice), 384 (Corrected invoice), 381 (Credit note)</c:description>
+      <c:description xml:lang="en">The element “Invoice type code” (BT-3) should only contain the following values from code list UNTDID 1001: 326 (Partial invoice), 380 (Commercial invoice), 384 (Corrected invoice), 381 (Credit note)</c:description>
       <c:restrictions>
         <c:codelist>
           <c:allowed-codes>326 380 384 381</c:allowed-codes>
@@ -278,7 +279,7 @@
     </c:rule>
 
     <c:rule id="BR-DE-18">
-      <c:description c:language="de">Informationen zur Gewährung von Skonto oder zur Berechnung von
+      <c:description xml:lang="de">Informationen zur Gewährung von Skonto oder zur Berechnung von
         Verzugszinsen müssen wie folgt im Element „Payment terms“ (BT-20) jeweils in einer eigenen
         Zeile übermittelt werden: Anzugeben ist im ersten Segment „SKONTO“ oder „VERZUG“, im zweiten
         „TAGE=n“, im dritten „PROZENT=n“, wobei die Segmente jeweils von einer „#“ umfasst sind.
@@ -287,7 +288,7 @@
         fälligen Betrags der Rechnung, ist der Grundwert zur Berechnung von Skonto oder Verzugszins
         als viertes Segment „BASISBETRAG=n“ mit dem semantischen Datentyp Amount
         anzugeben.</c:description>
-      <c:description c:language="en">Information on cash discount for prompt payment (Skonto) or default charges (Verzugszinsen) shall be provided within the element “Payment terms” BT-20 in the following way (one row per entry): First segment “SKONTO” or “VERZUG”, second segment amount of days (“TAGE=N”), third segment percentage (“PROZENT=N”) with segments enfolded by #. Percentage shall be separated by dot with two decimal places. In case the base value of the invoiced amount is not provided in BT-115 but as partial amount, the base value shall be provided as fourth segment “BASISBETRAG=N” as semantic data type amount.
+      <c:description xml:lang="en">Information on cash discount for prompt payment (Skonto) or default charges (Verzugszinsen) shall be provided within the element “Payment terms” BT-20 in the following way (one row per entry): First segment “SKONTO” or “VERZUG”, second segment amount of days (“TAGE=N”), third segment percentage (“PROZENT=N”) with segments enfolded by #. Percentage shall be separated by dot with two decimal places. In case the base value of the invoiced amount is not provided in BT-115 but as partial amount, the base value shall be provided as fourth segment “BASISBETRAG=N” as semantic data type amount.
 </c:description>
       <c:restrictions>
         <c:other>
@@ -300,7 +301,7 @@
     </c:rule>
 
     <c:rule id="BR-DE-19">
-      <c:description>The size of all attached documents together may not exceed 15MB</c:description>
+      <c:description xml:lang="en">The size of all attached documents together may not exceed 15MB</c:description>
       <c:restrictions>
         <c:other>
           <c:description>

--- a/schema/ce-config.xsd
+++ b/schema/ce-config.xsd
@@ -88,6 +88,8 @@
   <!-- A brief description of what the specification is intended for.-->
   <xs:element name="abstract" type="c:htmlType"/>
 
+  <!-- The development, production status of the CIUS or Extension-->
+  <xs:element name="status" type="xs:normalizedString"/>
 
   <!-- According to https://www.w3.org/International/questions/qa-when-xmllang it is NOT recommended to use xml>lang for natural language content of elements -->
   <xs:complexType name="htmlType">

--- a/schema/ce-config.xsd
+++ b/schema/ce-config.xsd
@@ -1,0 +1,178 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
+  targetNamespace="urn:x-namespace:yet:to:be:determined"
+  xmlns:c="urn:x-namespace:yet:to:be:determined">
+  <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="xml.xsd"/>
+  <xs:element name="config">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="c:meta"/>
+        <xs:element ref="c:desc"/>
+        <xs:element ref="c:rules"/>
+      </xs:sequence>
+      <!-- CIUS (TRUE) or Extension (FALSE)-->
+      <xs:attribute name="type" use="required" type="xs:boolean"/>
+
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="meta">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="c:nameShort"/>
+        <xs:element ref="c:nameLong"/>
+        <xs:element ref="c:nameTechnical"/>
+        <xs:element ref="c:version"/>
+        <xs:element ref="c:date"/>
+        <xs:element ref="c:publisher"/>
+        <xs:element ref="c:governor"/>
+        <xs:element minOccurs="0" ref="c:country"/>
+        <xs:element minOccurs="0" ref="c:sector"/>
+        <xs:element ref="c:email"/>
+        <xs:element ref="c:abstract"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <!-- A short descriptive name based on a common semantic -->
+  <xs:element name="nameShort" type="xs:string"/>
+  <!-- A descriptive name for general reference-->
+  <xs:element name="nameLong" type="xs:string"/>
+  <!-- Technical name (identifier) as described in "7.6 Identification of core invoice usage specifications"-->
+  <xs:element name="nameTechnical" type="xs:string"/>
+  <!-- NEW: Version of CIUS/Extension -->
+  <xs:element name="version" type="xs:string"/>
+  <!-- NEW: Date of publication of CIUS/Extension -->
+  <xs:element name="date" type="xs:date"/>
+  <!-- The party who formally publishes the specification.-->
+  <xs:element name="publisher" type="c:html-rtf"/>
+  <!-- The party who provides the specification its authority.-->
+  <xs:element name="governor" type="c:html-rtf"/>
+  <!--  One or more country codes, which the requirements the specification supports.-->
+  <xs:element name="country" type="xs:string"/>
+  <!-- The industry sector, which requirements the specification supports.-->
+  <xs:element name="sector" type="xs:string"/>
+  <!-- Contact to publisher.-->
+  <xs:element name="email" type="xs:string"/>
+  <!-- A brief description of what the specification is intended for.-->
+  <xs:element name="abstract" type="c:html-rtf"/>
+
+  <xs:element name="rules">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="c:rule"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="rule">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="c:desc"/>
+        <xs:choice maxOccurs="unbounded">
+          <xs:element ref="c:cardinality"/>
+          <xs:element ref="c:technical"/>
+          <xs:element ref="c:codelist"/>
+          <xs:element ref="c:format"/>
+          <xs:element ref="c:other"/>
+        </xs:choice>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="c:implementation"/>
+      </xs:sequence>
+      <xs:attribute name="id" use="required"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="desc">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="c:html-rtf">
+          <xs:attribute ref="xml:lang"/>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  
+  <xs:element name="cardinality">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="c:term"/>
+      </xs:sequence>
+      <xs:attribute name="maxOccurs">
+        <xs:simpleType>
+          <xs:union memberTypes="xs:integer">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="unbounded"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:union>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="minOccurs" type="xs:integer"/>
+    </xs:complexType>
+  </xs:element>
+  
+  <xs:element name="technical">
+    <xs:complexType/>
+  </xs:element>
+  
+  <xs:element name="codelist">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="c:term"/>
+        <xs:element maxOccurs="unbounded" ref="c:value"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  
+  <xs:element name="format">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="c:term"/>
+        <xs:element maxOccurs="unbounded" ref="c:pattern"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  
+  <xs:element name="other">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="c:term"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  
+  <xs:element name="pattern" type="xs:string"/>
+  <xs:element name="value" type="xs:string"/>
+  <xs:element name="term" type="xs:string"/>
+  
+  <xs:complexType name="html-rtf" mixed="true">
+    <xs:group minOccurs="0" maxOccurs="unbounded" ref="c:any-html"/>
+  </xs:complexType>
+  <xs:group name="any-html">
+    <xs:sequence>
+      <xs:any namespace="http://www.w3.org/1999/xhtml" processContents="skip"/>
+    </xs:sequence>
+  </xs:group>
+  <xs:attributeGroup name="any-attribute">
+    <xs:anyAttribute processContents="skip"/>
+  </xs:attributeGroup>
+  <xs:element name="implementation">
+    <xs:complexType>
+      <xs:complexContent>
+        <xs:extension base="c:any">
+          <xs:attribute name="syntax" use="required">
+            <xs:simpleType>
+              <xs:restriction base="xs:token">
+                <xs:enumeration value="UBL"/>
+                <xs:enumeration value="CII"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+        </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:complexType name="any">
+    <xs:sequence>
+      <xs:any processContents="skip"/>
+    </xs:sequence>
+  </xs:complexType>
+</xs:schema>

--- a/schema/ce-config.xsd
+++ b/schema/ce-config.xsd
@@ -4,11 +4,18 @@
   targetNamespace="urn:x-namespace:yet:to:be:determined"
   xmlns:c="urn:x-namespace:yet:to:be:determined">
 
+  <xs:group name="any-html">
+    <xs:sequence>
+      <xs:any namespace="http://www.w3.org/1999/xhtml" processContents="skip"/>
+    </xs:sequence>
+  </xs:group>
+
   <!-- 
    | Global simpleType Definitions
    -->
-  
+
   <!-- All semantic datatypes as defined by CEN except String type -->
+  <!-- See EN 16931-1:2017 chapter 6.5 -->
   <xs:simpleType name="restrictedSemanticDataTypeType">
     <xs:restriction base="xs:normalizedString">
       <xs:enumeration value="Binary"/>
@@ -25,28 +32,37 @@
       <xs:enumeration value="Binary object"/>
     </xs:restriction>
   </xs:simpleType>
-  
+
   <!-- String semantic datatype as defined by CEN -->
+  <!-- See EN 16931-1:2017 chapter 6.5 -->
   <xs:simpleType name="semanticStringTypeType">
     <xs:restriction base="xs:normalizedString">
       <xs:enumeration value="String"/>
     </xs:restriction>
   </xs:simpleType>
-  
+
   <!-- All semantic datatypes as defined by CEN -->
+  <!-- See EN 16931-1:2017 chapter 6.5 -->
   <xs:simpleType name="semanticDataTypeType">
     <xs:union
       memberTypes="c:restrictedSemanticDataTypeType c:semanticStringTypeType"/>
   </xs:simpleType>
-  
+
   <!-- 
    | Global Attribute Definitions
    -->
 
   <!-- Natural language of xml text content -->
+  <!-- According to
+    https://www.w3.org/International/questions/qa-when-xmllang.en
+    it is NOT recommended to use xml:lang for natural language content of elements -->
   <xs:attribute name="language" type="xs:normalizedString"/>
 
-  <!-- Indicates wheter an element is CIUS specific -->
+  <!-- Indicates wheter an element is CIUS specific. -->
+  <!-- It is a qualitativ
+    indicator although this might also be automatically deduced from comparisons
+    to main EN specification
+  -->
   <xs:attribute name="cius-specific" type="xs:boolean"/>
 
   <!-- 
@@ -58,7 +74,7 @@
   <!-- 
    | Global complexType Definitions
    -->
-  
+
   <xs:complexType name="html-rtf" mixed="true">
     <xs:group ref="c:any-html" minOccurs="0" maxOccurs="1"/>
   </xs:complexType>
@@ -78,39 +94,34 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-  
 
-  <xs:group name="any-html">
-    <xs:sequence>
-      <xs:any namespace="http://www.w3.org/1999/xhtml" processContents="skip"/>
-    </xs:sequence>
-  </xs:group>
-  
+  <!-- Defining reference with meatdata to a CEN codelist -->
   <xs:complexType name="codeListType">
     <xs:sequence>
       <!-- white listing subset of CEN codelist codes -->
       <xs:element name="allowed-codes" type="xs:token"/>
     </xs:sequence>
-    
+
     <!-- Shamelessly adopted and adapted from UBL 2.1 -->
     <xs:attribute name="listAgencyID" type="xs:normalizedString" use="optional"/>
-    
+    <!-- Shamelessly adopted and adapted from UBL 2.1 -->
     <xs:attribute name="listAgencyName" type="xs:string" use="optional"/>
-    
+    <!-- Shamelessly adopted and adapted from UBL 2.1 -->
     <xs:attribute name="listName" type="xs:string" use="optional"/>
-    
+    <!-- Shamelessly adopted and adapted from UBL 2.1 -->
     <xs:attribute name="listVersionID" type="xs:normalizedString" use="optional"/>
-    
+    <!-- Shamelessly adopted and adapted from UBL 2.1 -->
     <xs:attribute name="name" type="xs:string" use="optional"/>
-    
+    <!-- Main language of external codelist -->
     <xs:attribute ref="c:language" use="optional"/>
-    
+    <!-- Shamelessly adopted and adapted from UBL 2.1 -->
     <xs:attribute name="listURI" type="xs:anyURI" use="optional"/>
-    
+    <!-- Shamelessly adopted and adapted from UBL 2.1 -->
     <xs:attribute name="listSchemeURI" type="xs:anyURI" use="optional"/>
-    
   </xs:complexType>
-  
+
+  <!-- Restrictions defined on terms and by rules -->
+  <!-- See EN 16931-1:2017 chapter 7 -->
   <xs:complexType name="restrictionType">
     <xs:sequence>
       <xs:element ref="c:cardinality" minOccurs="0"/>
@@ -127,43 +138,48 @@
     <xs:sequence>
       <xs:element ref="c:definition"/>
       <xs:element ref="c:cardinality"/>
-      <xs:element ref="c:syntax-bindings"/>
+      <!-- optionally define the syntax binding of the BT or BG -->
+      <xs:element ref="c:syntax-bindings" minOccurs="0"/>
     </xs:sequence>
-    
+    <!-- ID of the term or group e.g. BT-1 or BG-11 -->
     <xs:attribute name="id" use="required" type="xs:ID"/>
+    <!-- The nesting level within Business Groups -->
     <xs:attribute name="level" use="required" type="xs:nonNegativeInteger"/>
+    <!-- Does it contian CIUS specific restrictions? -->
     <xs:attribute ref="c:cius-specific" use="required"/>
   </xs:complexType>
-  
+
+  <!-- The Business Group type -->
   <xs:complexType name="businessGroupType">
     <xs:complexContent>
       <xs:extension base="c:coreElementType"/>
     </xs:complexContent>
   </xs:complexType>
-  
-  
+
+  <!-- The Business Term type -->
   <xs:complexType name="businessTermType">
     <xs:complexContent>
       <xs:extension base="c:coreElementType">
         <xs:sequence>
+          <!-- Notes on how to use this BT -->
           <xs:element ref="c:usage-note" maxOccurs="1"/>
         </xs:sequence>
         <!-- This can be enhanced to contain simpleType and rules on the ids -->
         <xs:attribute name="business-group" use="optional" type="xs:IDREF"/>
-        
+        <!-- The semantic datatype of this BT -->
         <xs:attribute name="semantic-datatype" use="required"
           type="c:semanticDataTypeType"/>
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-  
-  
+
+
   <!-- 
    | Global Element Definitions
    -->
-  
+
   <!-- renzo: change most to normalized string then users do not need to implement own whitespace normalization -->
-  
+
   <!-- A short descriptive name based on a common semantic -->
   <xs:element name="nameShort" type="xs:normalizedString"/>
   <!-- A descriptive name for general reference-->
@@ -174,8 +190,17 @@
   <xs:element name="underlyingSpecification" type="xs:normalizedString"/>
   <!-- Version of the specification (This should be concat with the technical name equal to business term "Specification identification")-->
   <xs:element name="version" type="xs:normalizedString"/>
-  <!-- The status of the specification (PLANNED, DEVELOPMENT, ACTIVE, REVOKED)-->
-  <xs:element name="status" type="xs:normalizedString"/>
+  <!-- The status of the specification -->
+  <xs:element name="status" >
+    <xs:simpleType>
+      <xs:restriction base="xs:normalizedString">
+        <xs:enumeration value="planned"/>
+        <xs:enumeration value="development"/>
+        <xs:enumeration value="active"/>
+        <xs:enumeration value="revoked"/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:element>
   <!-- Date of publication of CIUS/Extension -->
   <xs:element name="date" type="xs:date"/>
   <!-- The party who formally publishes the specification.-->
@@ -192,7 +217,7 @@
   <xs:element name="abstract" type="c:html-rtf"/>
   <!-- A hyperlink to more detailed information about the specification. Preferably that should include contact information. -->
   <xs:element name="furtherInformation" type="xs:anyURI"/>
-  
+
   <xs:element name="metadata">
     <xs:complexType>
       <xs:sequence>
@@ -213,8 +238,8 @@
       </xs:sequence>
     </xs:complexType>
   </xs:element>
-  
-  
+
+
   <xs:element name="definition" type="c:htmlType"/>
   <xs:element name="description" type="c:htmlType"/>
   <xs:element name="term"/>
@@ -250,7 +275,7 @@
     </xs:complexType>
   </xs:element>
 
-  
+
   <xs:element name="codelist" type="c:codeListType"/>
 
   <xs:element name="value-domain">
@@ -364,6 +389,7 @@
   </xs:element>
 
   <!-- The root element of a CIUS description -->
+  <!-- See EN 16931-1:2017 chapter 7 -->
   <xs:element name="cius">
     <xs:complexType>
       <xs:sequence>

--- a/schema/ce-config.xsd
+++ b/schema/ce-config.xsd
@@ -2,20 +2,12 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
   targetNamespace="urn:x-namespace:yet:to:be:determined"
   xmlns:c="urn:x-namespace:yet:to:be:determined">
-  <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="xml.xsd"/>
-  <xs:element name="config">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element ref="c:meta"/>
-        <xs:element ref="c:desc"/>
-        <xs:element ref="c:rules"/>
-      </xs:sequence>
-      <!-- CIUS (TRUE) or Extension (FALSE)-->
-      <xs:attribute name="type" use="required" type="xs:boolean"/>
 
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="meta">
+  <!-- Natural language of xml text content -->
+  <xs:attribute name="language" type="xs:normalizedString"/>
+  <xs:attribute name="cius-specific" type="xs:boolean"/>
+
+  <xs:element name="metadata">
     <xs:complexType>
       <xs:sequence>
         <xs:element ref="c:nameShort"/>
@@ -32,71 +24,53 @@
       </xs:sequence>
     </xs:complexType>
   </xs:element>
+
+  <!-- renyo: change most to normalized string then users do not need to implement own whitespace normalization -->
+
   <!-- A short descriptive name based on a common semantic -->
-  <xs:element name="nameShort" type="xs:string"/>
+  <xs:element name="nameShort" type="xs:normalizedString"/>
   <!-- A descriptive name for general reference-->
-  <xs:element name="nameLong" type="xs:string"/>
+  <xs:element name="nameLong" type="xs:normalizedString"/>
   <!-- Technical name (identifier) as described in "7.6 Identification of core invoice usage specifications"-->
-  <xs:element name="nameTechnical" type="xs:string"/>
+  <xs:element name="nameTechnical" type="xs:normalizedString"/>
   <!-- NEW: Version of CIUS/Extension -->
-  <xs:element name="version" type="xs:string"/>
+  <xs:element name="version" type="xs:normalizedString"/>
   <!-- NEW: Date of publication of CIUS/Extension -->
   <xs:element name="date" type="xs:date"/>
   <!-- The party who formally publishes the specification.-->
-  <xs:element name="publisher" type="c:html-rtf"/>
+  <xs:element name="publisher" type="xs:normalizedString"/>
   <!-- The party who provides the specification its authority.-->
-  <xs:element name="governor" type="c:html-rtf"/>
+  <xs:element name="governor" type="xs:normalizedString"/>
   <!--  One or more country codes, which the requirements the specification supports.-->
-  <xs:element name="country" type="xs:string"/>
+
+  <!-- renzo: Better use ISO country codes -->
+  <xs:element name="country" type="xs:normalizedString"/>
   <!-- The industry sector, which requirements the specification supports.-->
-  <xs:element name="sector" type="xs:string"/>
+  <xs:element name="sector" type="xs:normalizedString"/>
   <!-- Contact to publisher.-->
-  <xs:element name="email" type="xs:string"/>
+  <xs:element name="email" type="xs:normalizedString"/>
   <!-- A brief description of what the specification is intended for.-->
   <xs:element name="abstract" type="c:html-rtf"/>
 
-  <xs:element name="rules">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element maxOccurs="unbounded" ref="c:rule"/>
-      </xs:sequence>
-    </xs:complexType>
-  </xs:element>
 
-  <xs:element name="rule">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element maxOccurs="unbounded" ref="c:desc"/>
-        <xs:choice maxOccurs="unbounded">
-          <xs:element ref="c:cardinality"/>
-          <xs:element ref="c:technical"/>
-          <xs:element ref="c:codelist"/>
-          <xs:element ref="c:format"/>
-          <xs:element ref="c:other"/>
-        </xs:choice>
-        <xs:element minOccurs="0" maxOccurs="unbounded" ref="c:implementation"/>
-      </xs:sequence>
-      <xs:attribute name="id" use="required"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="desc">
+  <!-- According to https://www.w3.org/International/questions/qa-when-xmllang it is NOT recommended to use xml>lang for natural language content of elements -->
+  <xs:element name="description">
     <xs:complexType>
       <xs:complexContent>
         <xs:extension base="c:html-rtf">
-          <xs:attribute ref="xml:lang"/>
+          <xs:attribute ref="c:language"/>
         </xs:extension>
       </xs:complexContent>
     </xs:complexType>
   </xs:element>
-  
+
+
+
   <xs:element name="cardinality">
     <xs:complexType>
-      <xs:sequence>
-        <xs:element maxOccurs="unbounded" ref="c:term"/>
-      </xs:sequence>
       <xs:attribute name="maxOccurs">
         <xs:simpleType>
-          <xs:union memberTypes="xs:integer">
+          <xs:union memberTypes="xs:nonNegativeInteger">
             <xs:simpleType>
               <xs:restriction base="xs:token">
                 <xs:enumeration value="unbounded"/>
@@ -105,14 +79,17 @@
           </xs:union>
         </xs:simpleType>
       </xs:attribute>
-      <xs:attribute name="minOccurs" type="xs:integer"/>
+      <xs:attribute name="minOccurs" type="xs:nonNegativeInteger"/>
     </xs:complexType>
   </xs:element>
-  
+
+  <xs:element name="usage-note" type="c:html-rtf"/>
+
+
   <xs:element name="technical">
     <xs:complexType/>
   </xs:element>
-  
+
   <xs:element name="codelist">
     <xs:complexType>
       <xs:sequence>
@@ -121,7 +98,7 @@
       </xs:sequence>
     </xs:complexType>
   </xs:element>
-  
+
   <xs:element name="format">
     <xs:complexType>
       <xs:sequence>
@@ -130,7 +107,7 @@
       </xs:sequence>
     </xs:complexType>
   </xs:element>
-  
+
   <xs:element name="other">
     <xs:complexType>
       <xs:sequence>
@@ -138,11 +115,11 @@
       </xs:sequence>
     </xs:complexType>
   </xs:element>
-  
+
   <xs:element name="pattern" type="xs:string"/>
   <xs:element name="value" type="xs:string"/>
-  <xs:element name="term" type="xs:string"/>
-  
+  <xs:element name="term" type="xs:normalizedString"/>
+
   <xs:complexType name="html-rtf" mixed="true">
     <xs:group minOccurs="0" maxOccurs="unbounded" ref="c:any-html"/>
   </xs:complexType>
@@ -175,4 +152,95 @@
       <xs:any processContents="skip"/>
     </xs:sequence>
   </xs:complexType>
+
+
+  <xs:complexType name="coreElementType" abstract="true">
+    <xs:sequence>
+      <xs:element maxOccurs="1" ref="c:description"/>
+      <xs:choice maxOccurs="1">
+        <xs:element ref="c:cardinality"/>
+        <xs:element ref="c:description"/>
+
+      </xs:choice>
+      <xs:element minOccurs="0" maxOccurs="unbounded" ref="c:implementation"/>
+    </xs:sequence>
+    <xs:attribute name="id" use="required" type="xs:ID"/>
+    <xs:attribute name="level" use="required" type="xs:nonNegativeInteger"/>
+    <xs:attribute ref="c:cius-specific" use="required"/>
+
+  </xs:complexType>
+
+  <xs:complexType name="businessGroupType">
+    <xs:complexContent>
+      <xs:extension base="c:coreElementType"/>
+    </xs:complexContent>
+  </xs:complexType>
+
+
+  <xs:complexType name="businessTermType">
+    <xs:complexContent>
+      <xs:extension base="c:coreElementType">
+        <xs:sequence>
+          <xs:element ref="c:usage-note" maxOccurs="1"/>
+        </xs:sequence>
+        <!-- This can be enhanced to contain simplytype and rules on the ids -->
+        <xs:attribute name="business-group" use="optional" type="xs:IDREF"/>
+        <!-- This can be enhanced to restrict to enumeration of allowed semantic datatypes -->
+        <xs:attribute name="semantic-datatype" use="required" type="xs:normalizedString"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:element name="core-element" type="c:coreElementType" abstract="true"/>
+  <xs:element name="busines-term" type="c:coreElementType" substitutionGroup="c:core-element"/>
+  <xs:element name="business-group" type="c:coreElementType" substitutionGroup="c:core-element"/>
+
+
+  <xs:element name="information-elements">
+    <xs:complexType>
+      <xs:sequence maxOccurs="unbounded">
+        <xs:element ref="c:core-element" maxOccurs="unbounded"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+
+  <xs:element name="rule">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="1" ref="c:description"/>
+
+        <xs:element minOccurs="0" maxOccurs="1" ref="c:implementation"/>
+      </xs:sequence>
+      <xs:attribute name="id" use="required" type="xs:ID"/>
+      <xs:attribute name="core-elements" type="xs:IDREFS" use="optional"/>
+      <xs:attribute ref="c:cius-specific" use="required"/>
+      
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="business-rules">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="c:rule" maxOccurs="unbounded"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+  <!-- Where to define extensions? as type attribute or as on element? -->
+  <xs:element name="cius">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="c:metadata"/>
+        <xs:element ref="c:description"/>
+        <xs:element ref="c:information-elements"/>
+        <xs:element ref="c:business-rules"/>
+      </xs:sequence>
+      <!-- CIUS (TRUE) or Extension (FALSE)-->
+      <!-- renzo: I would not use a bollean for extensibibilty eitehr enum or token -->
+      <xs:attribute name="type" use="required" type="xs:boolean"/>
+
+    </xs:complexType>
+  </xs:element>
+
 </xs:schema>

--- a/schema/ce-config.xsd
+++ b/schema/ce-config.xsd
@@ -40,8 +40,8 @@
         <xs:element ref="c:nameShort"/>
         <xs:element ref="c:nameLong"/>
         <xs:element ref="c:nameTechnical"/>
-        <!-- This should be equal to business term "Specification identification" -->
         <xs:element ref="c:version"/>
+        <xs:element ref="c:status"/>
         <xs:element ref="c:date"/>
         <xs:element ref="c:publisher"/>
         <xs:element ref="c:governor"/>
@@ -53,30 +53,38 @@
     </xs:complexType>
   </xs:element>
 
-  <!-- renyo: change most to normalized string then users do not need to implement own whitespace normalization -->
+  <!-- renzo: change most to normalized string then users do not need to implement own whitespace normalization -->
 
   <!-- A short descriptive name based on a common semantic -->
   <xs:element name="nameShort" type="xs:normalizedString"/>
+  
   <!-- A descriptive name for general reference-->
   <xs:element name="nameLong" type="xs:normalizedString"/>
-  <!-- Technical name (identifier) as described in "7.6 Identification of core invoice usage specifications"-->
+  
+  <!-- Technical name (identifier) as described in "7.6 Identification of core invoice usage specifications"  (This should be concat with the version equal to business term "Specification identification")-->
   <xs:element name="nameTechnical" type="xs:normalizedString"/>
-  <!-- NEW: Version of CIUS/Extension -->
+  
+  <!-- NEW: Version of CIUS/Extension (This should be concat with the technical name equal to business term "Specification identification")-->
   <xs:element name="version" type="xs:normalizedString"/>
+  
   <!-- NEW: Date of publication of CIUS/Extension -->
   <xs:element name="date" type="xs:date"/>
+  
   <!-- The party who formally publishes the specification.-->
   <xs:element name="publisher" type="xs:normalizedString"/>
+  
   <!-- The party who provides the specification its authority.-->
   <xs:element name="governor" type="xs:normalizedString"/>
-  <!--  One or more country codes, which the requirements the specification supports.-->
-
-  <!-- renzo: Better use ISO country codes -->
+  
+  <!--  One or more ISO country codes, which the requirements the specification supports.-->
   <xs:element name="country" type="xs:normalizedString"/>
+  
   <!-- The industry sector, which requirements the specification supports.-->
   <xs:element name="sector" type="xs:normalizedString"/>
+  
   <!-- Contact to publisher.-->
   <xs:element name="email" type="xs:normalizedString"/>
+  
   <!-- A brief description of what the specification is intended for.-->
   <xs:element name="abstract" type="c:htmlType"/>
 

--- a/schema/ce-config.xsd
+++ b/schema/ce-config.xsd
@@ -7,12 +7,40 @@
   <xs:attribute name="language" type="xs:normalizedString"/>
   <xs:attribute name="cius-specific" type="xs:boolean"/>
 
+
+
+  <xs:complexType name="html-rtf" mixed="true">
+    <xs:group ref="c:any-html" minOccurs="0" maxOccurs="1"/>
+  </xs:complexType>
+
+
+  <xs:group name="any-html">
+    <xs:sequence>
+      <xs:any namespace="http://www.w3.org/1999/xhtml" processContents="skip"/>
+    </xs:sequence>
+  </xs:group>
+
+
+  <xs:attributeGroup name="any-attribute">
+    <xs:anyAttribute processContents="skip"/>
+  </xs:attributeGroup>
+
+  <xs:complexType name="any">
+    <xs:sequence>
+      <xs:any processContents="skip"/>
+    </xs:sequence>
+  </xs:complexType>
+
+
+
+
   <xs:element name="metadata">
     <xs:complexType>
       <xs:sequence>
         <xs:element ref="c:nameShort"/>
         <xs:element ref="c:nameLong"/>
         <xs:element ref="c:nameTechnical"/>
+        <!-- This should be equal to business term "Specification identification" -->
         <xs:element ref="c:version"/>
         <xs:element ref="c:date"/>
         <xs:element ref="c:publisher"/>
@@ -50,21 +78,20 @@
   <!-- Contact to publisher.-->
   <xs:element name="email" type="xs:normalizedString"/>
   <!-- A brief description of what the specification is intended for.-->
-  <xs:element name="abstract" type="c:html-rtf"/>
+  <xs:element name="abstract" type="c:htmlType"/>
 
 
   <!-- According to https://www.w3.org/International/questions/qa-when-xmllang it is NOT recommended to use xml>lang for natural language content of elements -->
-  <xs:element name="description">
-    <xs:complexType>
-      <xs:complexContent>
-        <xs:extension base="c:html-rtf">
-          <xs:attribute ref="c:language"/>
-        </xs:extension>
-      </xs:complexContent>
-    </xs:complexType>
-  </xs:element>
+  <xs:complexType name="htmlType">
+    <xs:complexContent>
+      <xs:extension base="c:html-rtf">
+        <xs:attribute ref="c:language"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
 
-
+  <xs:element name="definition" type="c:htmlType"/>
+  <xs:element name="description" type="c:htmlType"/>
 
   <xs:element name="cardinality">
     <xs:complexType>
@@ -83,91 +110,127 @@
     </xs:complexType>
   </xs:element>
 
-  <xs:element name="usage-note" type="c:html-rtf"/>
+  <xs:element name="usage-note" type="c:htmlType"/>
 
 
   <xs:element name="technical">
     <xs:complexType/>
   </xs:element>
 
-  <xs:element name="codelist">
+  <xs:complexType name="codeListType">
+    <xs:sequence>
+      <!-- white listing subset of CEN codelist -->
+      <xs:element name="allowed-codes" type="xs:token"/>
+    </xs:sequence>
+
+    <!-- Shamelessly adopted and adpted from UBL 2.1 -->
+    <xs:attribute name="listAgencyID" type="xs:normalizedString" use="optional"/>
+
+    <xs:attribute name="listAgencyName" type="xs:string" use="optional"/>
+
+    <xs:attribute name="listName" type="xs:string" use="optional"/>
+
+    <xs:attribute name="listVersionID" type="xs:normalizedString" use="optional"/>
+
+    <xs:attribute name="name" type="xs:string" use="optional"/>
+
+    <xs:attribute ref="c:language" use="optional"/>
+
+    <xs:attribute name="listURI" type="xs:anyURI" use="optional"/>
+
+    <xs:attribute name="listSchemeURI" type="xs:anyURI" use="optional"/>
+
+  </xs:complexType>
+
+  <xs:element name="codelist" type="c:codeListType"/>
+
+  <xs:element name="value-domain">
     <xs:complexType>
-      <xs:sequence>
-        <xs:element maxOccurs="unbounded" ref="c:term"/>
-        <xs:element maxOccurs="unbounded" ref="c:value"/>
-      </xs:sequence>
+      <xs:attribute name="length" type="xs:nonNegativeInteger"/>
+      <xs:attribute name="format" type="xs:string"/>
+      <xs:attribute name="fraction-digit" type="xs:nonNegativeInteger"/>
     </xs:complexType>
   </xs:element>
 
-  <xs:element name="format">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element maxOccurs="unbounded" ref="c:term"/>
-        <xs:element maxOccurs="unbounded" ref="c:pattern"/>
-      </xs:sequence>
-    </xs:complexType>
-  </xs:element>
+  <xs:element name="semantic-definition" type="c:htmlType"/>
+
 
   <xs:element name="other">
     <xs:complexType>
       <xs:sequence>
-        <xs:element maxOccurs="unbounded" ref="c:term"/>
+        <xs:element maxOccurs="unbounded" ref="c:description"/>
       </xs:sequence>
     </xs:complexType>
   </xs:element>
 
-  <xs:element name="pattern" type="xs:string"/>
-  <xs:element name="value" type="xs:string"/>
-  <xs:element name="term" type="xs:normalizedString"/>
 
-  <xs:complexType name="html-rtf" mixed="true">
-    <xs:group minOccurs="0" maxOccurs="unbounded" ref="c:any-html"/>
-  </xs:complexType>
-  <xs:group name="any-html">
-    <xs:sequence>
-      <xs:any namespace="http://www.w3.org/1999/xhtml" processContents="skip"/>
-    </xs:sequence>
-  </xs:group>
-  <xs:attributeGroup name="any-attribute">
-    <xs:anyAttribute processContents="skip"/>
-  </xs:attributeGroup>
-  <xs:element name="implementation">
+  <xs:element name="syntax-bindings">
     <xs:complexType>
-      <xs:complexContent>
-        <xs:extension base="c:any">
+      <xs:simpleContent>
+        <xs:extension base="xs:string">
           <xs:attribute name="syntax" use="required">
             <xs:simpleType>
-              <xs:restriction base="xs:token">
-                <xs:enumeration value="UBL"/>
-                <xs:enumeration value="CII"/>
+              <xs:restriction base="xs:normalizedString">
+                <xs:enumeration value="ubl-invoice"/>
+                <xs:enumeration value="ubl-creditnote"/>
+                <xs:enumeration value="cii"/>
               </xs:restriction>
             </xs:simpleType>
           </xs:attribute>
         </xs:extension>
-      </xs:complexContent>
+      </xs:simpleContent>
     </xs:complexType>
   </xs:element>
-  <xs:complexType name="any">
-    <xs:sequence>
-      <xs:any processContents="skip"/>
-    </xs:sequence>
-  </xs:complexType>
+
+  <xs:element name="schematron">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:any namespace="http://purl.oclc.org/dsdl/schematron" processContents="lax"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+
+  <xs:simpleType name="restrictedSemanticDataTypeType">
+    <xs:restriction base="xs:normalizedString">
+      <xs:enumeration value="Binary"/>
+      <xs:enumeration value="Date"/>
+      <xs:enumeration value="Decimal"/>
+      <xs:enumeration value="Amount"/>
+      <xs:enumeration value="Unit price amount"/>
+      <xs:enumeration value="Quantity"/>
+      <xs:enumeration value="Percentage"/>
+      <xs:enumeration value="Identifier"/>
+      <xs:enumeration value="Document reference"/>
+      <xs:enumeration value="Code"/>
+      <xs:enumeration value="Text"/>
+      <xs:enumeration value="Binary object"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="semanticStringTypeType">
+    <xs:restriction base="xs:normalizedString">
+      <xs:enumeration value="String"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="semanticDataTypeType">
+    <xs:union memberTypes="c:restrictedSemanticDataTypeType c:semanticStringTypeType"/>
+  </xs:simpleType>
+
+  <xs:element name="semantic-datatype" type="c:restrictedSemanticDataTypeType"/>
 
 
   <xs:complexType name="coreElementType" abstract="true">
     <xs:sequence>
-      <xs:element maxOccurs="1" ref="c:description"/>
-      <xs:choice maxOccurs="1">
-        <xs:element ref="c:cardinality"/>
-        <xs:element ref="c:description"/>
-
-      </xs:choice>
-      <xs:element minOccurs="0" maxOccurs="unbounded" ref="c:implementation"/>
+      <xs:element ref="c:definition"/>
+      <xs:element ref="c:cardinality"/>
+      <xs:element ref="c:syntax-bindings"/>
     </xs:sequence>
+
     <xs:attribute name="id" use="required" type="xs:ID"/>
     <xs:attribute name="level" use="required" type="xs:nonNegativeInteger"/>
     <xs:attribute ref="c:cius-specific" use="required"/>
-
   </xs:complexType>
 
   <xs:complexType name="businessGroupType">
@@ -183,18 +246,29 @@
         <xs:sequence>
           <xs:element ref="c:usage-note" maxOccurs="1"/>
         </xs:sequence>
-        <!-- This can be enhanced to contain simplytype and rules on the ids -->
+        <!-- This can be enhanced to contain simpleType and rules on the ids -->
         <xs:attribute name="business-group" use="optional" type="xs:IDREF"/>
-        <!-- This can be enhanced to restrict to enumeration of allowed semantic datatypes -->
-        <xs:attribute name="semantic-datatype" use="required" type="xs:normalizedString"/>
+        
+        <xs:attribute name="semantic-datatype" use="required" type="c:semanticDataTypeType"/>
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
 
   <xs:element name="core-element" type="c:coreElementType" abstract="true"/>
-  <xs:element name="busines-term" type="c:coreElementType" substitutionGroup="c:core-element"/>
-  <xs:element name="business-group" type="c:coreElementType" substitutionGroup="c:core-element"/>
+  <xs:element name="busines-term" type="c:businessTermType" substitutionGroup="c:core-element"/>
+  <xs:element name="business-group" type="c:businessGroupType" substitutionGroup="c:core-element"/>
 
+
+  <xs:complexType name="restrictionType">
+    <xs:sequence>
+      <xs:element ref="c:cardinality" minOccurs="0"/>
+      <xs:element ref="c:codelist" minOccurs="0"/>
+      <xs:element ref="c:value-domain" minOccurs="0"/>
+      <xs:element ref="c:semantic-definition" minOccurs="0"/>
+      <xs:element ref="c:semantic-datatype" minOccurs="0"/>
+
+    </xs:sequence>
+  </xs:complexType>
 
   <xs:element name="information-elements">
     <xs:complexType>
@@ -204,18 +278,17 @@
     </xs:complexType>
   </xs:element>
 
-
   <xs:element name="rule">
     <xs:complexType>
       <xs:sequence>
-        <xs:element maxOccurs="1" ref="c:description"/>
-
-        <xs:element minOccurs="0" maxOccurs="1" ref="c:implementation"/>
+        <xs:element ref="c:description" maxOccurs="1"/>
+        <xs:element name="restrictions" type="c:restrictionType" minOccurs="0"/>
+        <xs:element ref="c:schematron" minOccurs="0"/>
       </xs:sequence>
       <xs:attribute name="id" use="required" type="xs:ID"/>
       <xs:attribute name="core-elements" type="xs:IDREFS" use="optional"/>
       <xs:attribute ref="c:cius-specific" use="required"/>
-      
+
     </xs:complexType>
   </xs:element>
 
@@ -232,8 +305,9 @@
     <xs:complexType>
       <xs:sequence>
         <xs:element ref="c:metadata"/>
+        <!-- maybe to redundant to the abstract elem within metadata -->
         <xs:element ref="c:description"/>
-        <xs:element ref="c:information-elements"/>
+        <xs:element ref="c:information-elements" minOccurs="0"/>
         <xs:element ref="c:business-rules"/>
       </xs:sequence>
       <!-- CIUS (TRUE) or Extension (FALSE)-->

--- a/schema/ce-config.xsd
+++ b/schema/ce-config.xsd
@@ -55,34 +55,34 @@
 
   <!-- A short descriptive name based on a common semantic -->
   <xs:element name="nameShort" type="xs:normalizedString"/>
-  
+
   <!-- A descriptive name for general reference-->
   <xs:element name="nameLong" type="xs:normalizedString"/>
-  
+
   <!-- Technical name (identifier) as described in "7.6 Identification of core invoice usage specifications"  (This should be concat with the version equal to business term "Specification identification")-->
   <xs:element name="nameTechnical" type="xs:normalizedString"/>
-  
+
   <!-- NEW: Version of CIUS/Extension (This should be concat with the technical name equal to business term "Specification identification")-->
   <xs:element name="version" type="xs:normalizedString"/>
-  
+
   <!-- NEW: Date of publication of CIUS/Extension -->
   <xs:element name="date" type="xs:date"/>
-  
+
   <!-- The party who formally publishes the specification.-->
   <xs:element name="publisher" type="c:html-rtf"/>
-  
+
   <!-- The party who provides the specification its authority.-->
   <xs:element name="governor" type="xs:normalizedString"/>
-  
+
   <!--  One or more ISO country codes, which the requirements the specification supports.-->
   <xs:element name="country" type="xs:normalizedString"/>
-  
+
   <!-- The industry sector, which requirements the specification supports.-->
   <xs:element name="sector" type="xs:normalizedString"/>
-  
+
   <!-- Contact to publisher.-->
   <xs:element name="email" type="xs:normalizedString"/>
-  
+
   <!-- A brief description of what the specification is intended for.-->
   <xs:element name="abstract" type="c:html-rtf"/>
 
@@ -100,9 +100,13 @@
 
   <xs:element name="definition" type="c:htmlType"/>
   <xs:element name="description" type="c:htmlType"/>
+  <xs:element name="term"/>
 
   <xs:element name="cardinality">
     <xs:complexType>
+      <xs:sequence>
+        <xs:element name="term" minOccurs="1" maxOccurs="unbounded"/>
+      </xs:sequence>
       <xs:attribute name="maxOccurs">
         <xs:simpleType>
           <xs:union memberTypes="xs:nonNegativeInteger">
@@ -122,34 +126,30 @@
 
 
   <xs:element name="technical">
-    <xs:complexType/>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="c:term" minOccurs="1" maxOccurs="unbounded"/>
+      </xs:sequence>
+    </xs:complexType>
   </xs:element>
 
   <xs:complexType name="codeListType">
     <xs:sequence>
+      <xs:element ref="c:term"/>
       <!-- white listing subset of CEN codelist -->
       <xs:element name="allowed-codes" type="xs:token"/>
     </xs:sequence>
-
     <!-- Shamelessly adopted and adpted from UBL 2.1 -->
     <xs:attribute name="listAgencyID" type="xs:normalizedString" use="optional"/>
-
     <xs:attribute name="listAgencyName" type="xs:string" use="optional"/>
-
     <xs:attribute name="listName" type="xs:string" use="optional"/>
-
     <xs:attribute name="listVersionID" type="xs:normalizedString" use="optional"/>
-
     <xs:attribute name="name" type="xs:string" use="optional"/>
-
     <xs:attribute ref="c:language" use="optional"/>
-
     <xs:attribute name="listURI" type="xs:anyURI" use="optional"/>
-
     <xs:attribute name="listSchemeURI" type="xs:anyURI" use="optional"/>
-
   </xs:complexType>
-
+  
   <xs:element name="codelist" type="c:codeListType"/>
 
   <xs:element name="value-domain">
@@ -160,7 +160,13 @@
     </xs:complexType>
   </xs:element>
 
-  <xs:element name="semantic-definition" type="c:htmlType"/>
+  <xs:element name="semantic-definition" type="c:htmlType">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="c:term"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
 
 
   <xs:element name="other">
@@ -256,7 +262,7 @@
         </xs:sequence>
         <!-- This can be enhanced to contain simpleType and rules on the ids -->
         <xs:attribute name="business-group" use="optional" type="xs:IDREF"/>
-        
+
         <xs:attribute name="semantic-datatype" use="required" type="c:semanticDataTypeType"/>
       </xs:extension>
     </xs:complexContent>
@@ -269,12 +275,12 @@
 
   <xs:complexType name="restrictionType">
     <xs:sequence>
-      <xs:element ref="c:cardinality" minOccurs="0"/>
-      <xs:element ref="c:codelist" minOccurs="0"/>
-      <xs:element ref="c:value-domain" minOccurs="0"/>
-      <xs:element ref="c:semantic-definition" minOccurs="0"/>
-      <xs:element ref="c:semantic-datatype" minOccurs="0"/>
-      <xs:element ref="c:other" minOccurs="0"/>
+      <xs:element ref="c:cardinality" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element ref="c:codelist" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element ref="c:value-domain" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element ref="c:semantic-definition" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element ref="c:semantic-datatype" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element ref="c:other" minOccurs="0" maxOccurs="1"/>
     </xs:sequence>
   </xs:complexType>
 
@@ -294,11 +300,11 @@
         <xs:element ref="c:schematron" minOccurs="0"/>
       </xs:sequence>
       <xs:attribute name="id" use="required" type="xs:ID"/>
-      <xs:attribute name="core-elements" use="optional">
-        <xs:simpleType>
-          <xs:list itemType="xs:normalizedString"></xs:list>
-        </xs:simpleType>
-      </xs:attribute>
+      <!-- information given within the attribute will be given explicitly within the restriction element -->
+      <!-- <xs:attribute name="core-elements" use="optional">-->
+      <!-- <xs:simpleType><xs:list itemType="xs:normalizedString"/></xs:simpleType>-->
+      <!--</xs:attribute>-->
+
       <xs:attribute ref="c:cius-specific" use="optional"/>
 
     </xs:complexType>

--- a/schema/ce-config.xsd
+++ b/schema/ce-config.xsd
@@ -7,8 +7,6 @@
   <xs:attribute name="language" type="xs:normalizedString"/>
   <xs:attribute name="cius-specific" type="xs:boolean"/>
 
-
-
   <xs:complexType name="html-rtf" mixed="true">
     <xs:group ref="c:any-html" minOccurs="0" maxOccurs="1"/>
   </xs:complexType>
@@ -26,7 +24,7 @@
   </xs:attributeGroup>
 
   <xs:complexType name="any">
-    <xs:sequence>
+    <xs:sequence maxOccurs="unbounded">
       <xs:any processContents="skip"/>
     </xs:sequence>
   </xs:complexType>
@@ -71,7 +69,7 @@
   <xs:element name="date" type="xs:date"/>
   
   <!-- The party who formally publishes the specification.-->
-  <xs:element name="publisher" type="xs:normalizedString"/>
+  <xs:element name="publisher" type="c:html-rtf"/>
   
   <!-- The party who provides the specification its authority.-->
   <xs:element name="governor" type="xs:normalizedString"/>
@@ -86,7 +84,7 @@
   <xs:element name="email" type="xs:normalizedString"/>
   
   <!-- A brief description of what the specification is intended for.-->
-  <xs:element name="abstract" type="c:htmlType"/>
+  <xs:element name="abstract" type="c:html-rtf"/>
 
   <!-- The development, production status of the CIUS or Extension-->
   <xs:element name="status" type="xs:normalizedString"/>
@@ -168,7 +166,7 @@
   <xs:element name="other">
     <xs:complexType>
       <xs:sequence>
-        <xs:element maxOccurs="unbounded" ref="c:description"/>
+        <xs:element name="description" maxOccurs="unbounded" type="c:any"/>
       </xs:sequence>
     </xs:complexType>
   </xs:element>
@@ -276,7 +274,7 @@
       <xs:element ref="c:value-domain" minOccurs="0"/>
       <xs:element ref="c:semantic-definition" minOccurs="0"/>
       <xs:element ref="c:semantic-datatype" minOccurs="0"/>
-      <xs:element ref="c:other"/>
+      <xs:element ref="c:other" minOccurs="0"/>
     </xs:sequence>
   </xs:complexType>
 
@@ -291,13 +289,17 @@
   <xs:element name="rule">
     <xs:complexType>
       <xs:sequence>
-        <xs:element ref="c:description" maxOccurs="1"/>
+        <xs:element ref="c:description" maxOccurs="unbounded"/>
         <xs:element name="restrictions" type="c:restrictionType" minOccurs="0"/>
         <xs:element ref="c:schematron" minOccurs="0"/>
       </xs:sequence>
       <xs:attribute name="id" use="required" type="xs:ID"/>
-      <xs:attribute name="core-elements" type="xs:IDREFS" use="optional"/>
-      <xs:attribute ref="c:cius-specific" use="required"/>
+      <xs:attribute name="core-elements" use="optional">
+        <xs:simpleType>
+          <xs:list itemType="xs:normalizedString"></xs:list>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute ref="c:cius-specific" use="optional"/>
 
     </xs:complexType>
   </xs:element>

--- a/schema/ce-config.xsd
+++ b/schema/ce-config.xsd
@@ -175,7 +175,7 @@
     <!-- The nesting level within Business Groups -->
     <xs:attribute name="level" use="optional" type="xs:nonNegativeInteger"/>
     <!-- Does it contian CIUS specific restrictions? -->
-    <xs:attribute name="cius-specific" type="xs:boolean" use="required"/>
+    <xs:attribute name="cius-specific" type="xs:boolean" use="optional"/>
   </xs:complexType>
 
   <!-- The Business Group type -->
@@ -216,6 +216,14 @@
       <xs:element ref="c:information-elements" minOccurs="0"/>
       <xs:element ref="c:business-rules"/>
     </xs:sequence>
+    <xs:attribute name="type" use="required">
+      <xs:simpleType>
+        <xs:restriction base="xs:normalizedString">
+          <xs:enumeration value="restriction"/>
+          <xs:enumeration value="extension"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
   </xs:complexType>
 
   <!-- Type of the root element extension a restriction of
@@ -356,7 +364,7 @@
   <xs:element name="semantic-definition">
     <xs:complexType>
       <xs:sequence>
-        <xs:element ref="c:term"/>
+        <xs:element ref="c:term" maxOccurs="unbounded"/>
       </xs:sequence>
       <xs:attributeGroup ref="c:terms"/>
     </xs:complexType>
@@ -453,7 +461,7 @@
       </xs:attribute>
       -->
       <!-- If it is a CIUS specific restriction -->
-      <xs:attribute name="cius-specific" type="xs:boolean" use="required"/>
+      <xs:attribute name="cius-specific" type="xs:boolean" use="optional"/>
 
     </xs:complexType>
   </xs:element>

--- a/schema/ce-config.xsd
+++ b/schema/ce-config.xsd
@@ -35,7 +35,14 @@
   <xs:attributeGroup name="codelistRequiredListNameAttributeGroup">
     <xs:attributeGroup ref="c:codelistNoListNameAttributeGroup"/>
     <xs:attribute name="listName" type="xs:string" use="required"/>
+  </xs:attributeGroup>
 
+  <xs:attributeGroup name="terms">
+    <xs:attribute name="term" use="optional">
+      <xs:simpleType>
+        <xs:list itemType="xs:normalizedString"/>
+      </xs:simpleType>
+    </xs:attribute>
   </xs:attributeGroup>
 
   <xs:group name="any-html">
@@ -64,7 +71,7 @@
       <xs:enumeration value="Code"/>
       <xs:enumeration value="Text"/>
       <xs:enumeration value="Binary object"/>
-    </xs:restriction>
+    </xs:restriction>  
   </xs:simpleType>
 
   <!-- String semantic datatype as defined by CEN -->
@@ -123,6 +130,7 @@
       <xs:element name="allowed-codes" type="xs:token"/>
     </xs:sequence>
     <xs:attributeGroup ref="c:codelistNoListNameAttributeGroup"/>
+    <xs:attributeGroup ref="c:terms"/>
   </xs:complexType>
 
   <!-- Defining reference with meatdata to a CEN codelist -->
@@ -184,9 +192,10 @@
         <xs:sequence>
           <!-- Notes on how to use this BT -->
           <xs:element ref="c:usage-note" minOccurs="0"/>
-          <xs:element name="codelist-restriction" type="c:codeListRistrictionType"
+          <xs:element name="codelist-restriction"
+            type="c:codeListRistrictionType" minOccurs="0"/>
+          <xs:element name="codelist-values" type="c:codeWhiteListType"
             minOccurs="0"/>
-          <xs:element name="codelist-values" type="c:codeWhiteListType" minOccurs="0"/>
         </xs:sequence>
         <!-- This can be enhanced to contain simpleType and rules on the ids -->
         <xs:attribute name="business-group" use="optional" type="xs:IDREF"/>
@@ -303,7 +312,8 @@
       <!--<xs:sequence>
         <xs:element name="term" minOccurs="1" maxOccurs="unbounded"/>
       </xs:sequence>-->
-      <xs:attribute name="term" type="xs:normalizedString" use="optional"/>
+      <xs:attributeGroup ref="c:terms"/>
+      
       <xs:attribute name="maxOccurs">
         <xs:simpleType>
           <xs:union memberTypes="xs:nonNegativeInteger">
@@ -316,7 +326,7 @@
         </xs:simpleType>
       </xs:attribute>
       <xs:attribute name="minOccurs" type="xs:nonNegativeInteger"/>
-      
+
     </xs:complexType>
   </xs:element>
 
@@ -339,6 +349,7 @@
       <xs:attribute name="length" type="xs:nonNegativeInteger"/>
       <xs:attribute name="format" type="xs:string"/>
       <xs:attribute name="fraction-digit" type="xs:nonNegativeInteger"/>
+      <xs:attributeGroup ref="c:terms"/>
     </xs:complexType>
   </xs:element>
 
@@ -347,6 +358,7 @@
       <xs:sequence>
         <xs:element ref="c:term"/>
       </xs:sequence>
+      <xs:attributeGroup ref="c:terms"/>
     </xs:complexType>
   </xs:element>
 
@@ -356,6 +368,7 @@
       <xs:sequence>
         <xs:element name="description" maxOccurs="unbounded" type="c:any"/>
       </xs:sequence>
+      <xs:attributeGroup ref="c:terms"/>
     </xs:complexType>
   </xs:element>
 
@@ -387,7 +400,15 @@
     </xs:complexType>
   </xs:element>
 
-  <xs:element name="semantic-datatype" type="c:restrictedSemanticDataTypeType"/>
+  <xs:element name="semantic-datatype" >
+    <xs:complexType>
+      <xs:simpleContent>
+        <xs:extension base="c:restrictedSemanticDataTypeType">
+          <xs:attributeGroup ref="c:terms"/>
+        </xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
+  </xs:element>
 
 
 
@@ -424,11 +445,13 @@
       </xs:sequence>
 
       <xs:attribute name="id" use="required" type="xs:ID"/>
+      <!-- as for time being 
       <xs:attribute name="core-elements" use="optional">
         <xs:simpleType>
           <xs:list itemType="xs:normalizedString"/>
         </xs:simpleType>
       </xs:attribute>
+      -->
       <!-- If it is a CIUS specific restriction -->
       <xs:attribute name="cius-specific" type="xs:boolean" use="required"/>
 

--- a/schema/ce-config.xsd
+++ b/schema/ce-config.xsd
@@ -8,6 +8,35 @@
   <xs:import namespace="http://www.w3.org/XML/1998/namespace"
     schemaLocation="http://www.w3.org/2001/xml.xsd"/>
 
+  <xs:attributeGroup name="codelistNoListNameAttributeGroup">
+    <!-- Shamelessly adopted and adapted from UBL 2.1 -->
+    <xs:attribute name="listAgencyID" type="xs:normalizedString" use="optional"/>
+    <!-- Shamelessly adopted and adapted from UBL 2.1 -->
+    <xs:attribute name="listAgencyName" type="xs:string" use="optional"/>
+
+    <!-- Shamelessly adopted and adapted from UBL 2.1 -->
+    <xs:attribute name="listVersionID" type="xs:normalizedString" use="optional"/>
+    <!-- Shamelessly adopted and adapted from UBL 2.1 -->
+    <xs:attribute name="name" type="xs:string" use="optional"/>
+    <!-- Main language of external codelist -->
+    <!-- Natural language of xml text content -->
+    <!-- According to
+    https://www.w3.org/International/questions/qa-when-xmllang.en
+    it is NOT recommended to use xml:lang for natural language content of
+    external elements. Hence definition of own language attribute. -->
+    <xs:attribute name="language" type="xs:normalizedString" use="optional"/>
+    <!-- Shamelessly adopted and adapted from UBL 2.1 -->
+    <xs:attribute name="listURI" type="xs:anyURI" use="optional"/>
+    <!-- Shamelessly adopted and adapted from UBL 2.1 -->
+    <xs:attribute name="listSchemeURI" type="xs:anyURI" use="optional"/>
+  </xs:attributeGroup>
+
+
+  <xs:attributeGroup name="codelistRequiredListNameAttributeGroup">
+    <xs:attributeGroup ref="c:codelistNoListNameAttributeGroup"/>
+    <xs:attribute name="listName" type="xs:string" use="required"/>
+
+  </xs:attributeGroup>
 
   <xs:group name="any-html">
     <xs:sequence>
@@ -53,18 +82,11 @@
       memberTypes="c:restrictedSemanticDataTypeType c:semanticStringTypeType"/>
   </xs:simpleType>
 
-
-  <!-- 
-  <xs:attributeGroup name="any-attribute">
-    <xs:anyAttribute processContents="skip"/>
-  </xs:attributeGroup>
-   -->
-
   <!-- 
    | Global complexType Definitions
    -->
 
-  <!-- Inlcude html content but no xml:lang attribute required. Use htmlType if
+  <!-- Include html content but no xml:lang attribute required. Use htmlType if
     xml:lang is requires -->
   <xs:complexType name="html-rtf" mixed="true">
     <xs:group ref="c:any-html" minOccurs="0" maxOccurs="1"/>
@@ -87,34 +109,26 @@
     </xs:complexContent>
   </xs:complexType>
 
+
   <!-- Defining reference with meatdata to a CEN codelist -->
   <xs:complexType name="codeListType">
+    <xs:attributeGroup ref="c:codelistNoListNameAttributeGroup"/>
+  </xs:complexType>
+
+
+  <!-- Defining reference with meatdata to a CEN codelist -->
+  <xs:complexType name="codeWhiteListType">
     <xs:sequence>
       <!-- white listing subset of CEN codelist codes -->
       <xs:element name="allowed-codes" type="xs:token"/>
     </xs:sequence>
+    <xs:attributeGroup ref="c:codelistNoListNameAttributeGroup"/>
+  </xs:complexType>
 
-    <!-- Shamelessly adopted and adapted from UBL 2.1 -->
-    <xs:attribute name="listAgencyID" type="xs:normalizedString" use="optional"/>
-    <!-- Shamelessly adopted and adapted from UBL 2.1 -->
-    <xs:attribute name="listAgencyName" type="xs:string" use="optional"/>
-    <!-- Shamelessly adopted and adapted from UBL 2.1 -->
-    <xs:attribute name="listName" type="xs:string" use="optional"/>
-    <!-- Shamelessly adopted and adapted from UBL 2.1 -->
-    <xs:attribute name="listVersionID" type="xs:normalizedString" use="optional"/>
-    <!-- Shamelessly adopted and adapted from UBL 2.1 -->
-    <xs:attribute name="name" type="xs:string" use="optional"/>
-    <!-- Main language of external codelist -->
-    <!-- Natural language of xml text content -->
-    <!-- According to
-    https://www.w3.org/International/questions/qa-when-xmllang.en
-    it is NOT recommended to use xml:lang for natural language content of
-    external elements. Hence definition of own language attribute. -->
-    <xs:attribute name="language" type="xs:normalizedString" use="optional"/>
-    <!-- Shamelessly adopted and adapted from UBL 2.1 -->
-    <xs:attribute name="listURI" type="xs:anyURI" use="optional"/>
-    <!-- Shamelessly adopted and adapted from UBL 2.1 -->
-    <xs:attribute name="listSchemeURI" type="xs:anyURI" use="optional"/>
+  <!-- Defining reference with meatdata to a CEN codelist -->
+  <xs:complexType name="codeListRistrictionType">
+    <xs:attributeGroup ref="c:codelistRequiredListNameAttributeGroup"/>
+    <xs:attribute name="removed" type="xs:boolean" fixed="true" use="required"/>
   </xs:complexType>
 
   <!-- Restrictions defined on terms and by rules -->
@@ -130,18 +144,28 @@
     </xs:sequence>
   </xs:complexType>
 
+  <xs:complexType name="synonymType">
+    <xs:simpleContent>
+      <xs:extension base="xs:normalizedString">
+        <xs:attribute ref="xml:lang" use="required"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
   <!-- General abstract XML type with common elements and attributes for Business Terms and Business Rules -->
   <xs:complexType name="coreElementType" abstract="true">
     <xs:sequence>
-      <xs:element ref="c:definition"/>
-      <xs:element ref="c:cardinality"/>
+      <xs:element name="synonym" type="c:synonymType" minOccurs="0"
+        maxOccurs="unbounded"/>
+      <xs:element ref="c:definition" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element ref="c:cardinality" minOccurs="0"/>
       <!-- optionally define the syntax binding of the BT or BG -->
       <xs:element ref="c:syntax-bindings" minOccurs="0"/>
     </xs:sequence>
     <!-- ID of the term or group e.g. BT-1 or BG-11 -->
     <xs:attribute name="id" use="required" type="xs:ID"/>
     <!-- The nesting level within Business Groups -->
-    <xs:attribute name="level" use="required" type="xs:nonNegativeInteger"/>
+    <xs:attribute name="level" use="optional" type="xs:nonNegativeInteger"/>
     <!-- Does it contian CIUS specific restrictions? -->
     <xs:attribute name="cius-specific" type="xs:boolean" use="required"/>
   </xs:complexType>
@@ -159,12 +183,15 @@
       <xs:extension base="c:coreElementType">
         <xs:sequence>
           <!-- Notes on how to use this BT -->
-          <xs:element ref="c:usage-note" maxOccurs="1"/>
+          <xs:element ref="c:usage-note" minOccurs="0"/>
+          <xs:element name="codelist-restriction" type="c:codeListRistrictionType"
+            minOccurs="0"/>
+          <xs:element name="codelist-values" type="c:codeWhiteListType" minOccurs="0"/>
         </xs:sequence>
         <!-- This can be enhanced to contain simpleType and rules on the ids -->
         <xs:attribute name="business-group" use="optional" type="xs:IDREF"/>
         <!-- The semantic datatype of this BT -->
-        <xs:attribute name="semantic-datatype" use="required"
+        <xs:attribute name="semantic-datatype" use="optional"
           type="c:semanticDataTypeType"/>
       </xs:extension>
     </xs:complexContent>
@@ -273,9 +300,10 @@
   <!--  -->
   <xs:element name="cardinality">
     <xs:complexType>
-      <xs:sequence>
+      <!--<xs:sequence>
         <xs:element name="term" minOccurs="1" maxOccurs="unbounded"/>
-      </xs:sequence>
+      </xs:sequence>-->
+      <xs:attribute name="term" type="xs:normalizedString" use="optional"/>
       <xs:attribute name="maxOccurs">
         <xs:simpleType>
           <xs:union memberTypes="xs:nonNegativeInteger">
@@ -288,6 +316,7 @@
         </xs:simpleType>
       </xs:attribute>
       <xs:attribute name="minOccurs" type="xs:nonNegativeInteger"/>
+      
     </xs:complexType>
   </xs:element>
 
@@ -303,7 +332,7 @@
   </xs:element>
 
 
-  <xs:element name="codelist" type="c:codeListType"/>
+  <xs:element name="codelist" type="c:codeWhiteListType"/>
 
   <xs:element name="value-domain">
     <xs:complexType>

--- a/schema/ce-config.xsd
+++ b/schema/ce-config.xsd
@@ -265,7 +265,7 @@
   </xs:complexType>
 
   <xs:element name="core-element" type="c:coreElementType" abstract="true"/>
-  <xs:element name="busines-term" type="c:businessTermType" substitutionGroup="c:core-element"/>
+  <xs:element name="business-term" type="c:businessTermType" substitutionGroup="c:core-element"/>
   <xs:element name="business-group" type="c:businessGroupType" substitutionGroup="c:core-element"/>
 
 
@@ -276,7 +276,7 @@
       <xs:element ref="c:value-domain" minOccurs="0"/>
       <xs:element ref="c:semantic-definition" minOccurs="0"/>
       <xs:element ref="c:semantic-datatype" minOccurs="0"/>
-
+      <xs:element ref="c:other"/>
     </xs:sequence>
   </xs:complexType>
 

--- a/schema/ce-config.xsd
+++ b/schema/ce-config.xsd
@@ -11,13 +11,11 @@
     <xs:group ref="c:any-html" minOccurs="0" maxOccurs="1"/>
   </xs:complexType>
 
-
   <xs:group name="any-html">
     <xs:sequence>
       <xs:any namespace="http://www.w3.org/1999/xhtml" processContents="skip"/>
     </xs:sequence>
   </xs:group>
-
 
   <xs:attributeGroup name="any-attribute">
     <xs:anyAttribute processContents="skip"/>
@@ -29,7 +27,9 @@
     </xs:sequence>
   </xs:complexType>
 
-
+  <!---\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-->
+  <!--                          Metadata                                                                                            -->
+  <!---\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-->
 
 
   <xs:element name="metadata">
@@ -38,6 +38,7 @@
         <xs:element ref="c:nameShort"/>
         <xs:element ref="c:nameLong"/>
         <xs:element ref="c:nameTechnical"/>
+        <xs:element ref="c:underlyingSpecification"/>
         <xs:element ref="c:version"/>
         <xs:element ref="c:status"/>
         <xs:element ref="c:date"/>
@@ -45,51 +46,83 @@
         <xs:element ref="c:governor"/>
         <xs:element minOccurs="0" ref="c:country"/>
         <xs:element minOccurs="0" ref="c:sector"/>
-        <xs:element ref="c:email"/>
+        <xs:element ref="c:contact"/>
         <xs:element ref="c:abstract"/>
+        <xs:element ref="c:furtherInformation"/>
       </xs:sequence>
     </xs:complexType>
   </xs:element>
 
-  <!-- renzo: change most to normalized string then users do not need to implement own whitespace normalization -->
 
   <!-- A short descriptive name based on a common semantic -->
   <xs:element name="nameShort" type="xs:normalizedString"/>
-
   <!-- A descriptive name for general reference-->
   <xs:element name="nameLong" type="xs:normalizedString"/>
-
   <!-- Technical name (identifier) as described in "7.6 Identification of core invoice usage specifications"  (This should be concat with the version equal to business term "Specification identification")-->
   <xs:element name="nameTechnical" type="xs:normalizedString"/>
-
-  <!-- NEW: Version of CIUS/Extension (This should be concat with the technical name equal to business term "Specification identification")-->
+  <!-- The specification that is used as base. A valid instance according to a CIUS specification must also be valid according to its underlying specification. If not it is an extension. -->
+  <xs:element name="underlyingSpecification" type="xs:normalizedString"/>
+  <!-- Version of the specification (This should be concat with the technical name equal to business term "Specification identification")-->
   <xs:element name="version" type="xs:normalizedString"/>
-
-  <!-- NEW: Date of publication of CIUS/Extension -->
+  <!-- The status of the specification (PLANNED, DEVELOPMENT, ACTIVE, REVOKED)-->
+  <xs:element name="status" type="xs:normalizedString"/>
+  <!-- Date of publication of CIUS/Extension -->
   <xs:element name="date" type="xs:date"/>
-
   <!-- The party who formally publishes the specification.-->
   <xs:element name="publisher" type="c:html-rtf"/>
-
   <!-- The party who provides the specification its authority.-->
   <xs:element name="governor" type="xs:normalizedString"/>
-
   <!--  One or more ISO country codes, which the requirements the specification supports.-->
   <xs:element name="country" type="xs:normalizedString"/>
-
   <!-- The industry sector, which requirements the specification supports.-->
   <xs:element name="sector" type="xs:normalizedString"/>
-
-  <!-- Contact to publisher.-->
-  <xs:element name="email" type="xs:normalizedString"/>
-
+  <!-- e-Mail contact to publisher.-->
+  <xs:element name="contact" type="xs:normalizedString"/>
   <!-- A brief description of what the specification is intended for.-->
   <xs:element name="abstract" type="c:html-rtf"/>
+  <!-- A hyperlink to more detailed information about the specification. Preferably that should include contact information. -->
+  <xs:element name="furtherInformation" type="xs:string"/>
 
-  <!-- The development, production status of the CIUS or Extension-->
-  <xs:element name="status" type="xs:normalizedString"/>
 
-  <!-- According to https://www.w3.org/International/questions/qa-when-xmllang it is NOT recommended to use xml>lang for natural language content of elements -->
+  <!---\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-->
+  <!--                          Data                                                                                                -->
+  <!---\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-->
+
+  <xs:element name="business-rules">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="c:rule" maxOccurs="unbounded"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="rule">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="c:description" maxOccurs="unbounded"/>
+        <xs:element name="restrictions" type="c:restrictionType" minOccurs="0"/>
+        <xs:element ref="c:schematron" minOccurs="0"/>
+      </xs:sequence>
+      <xs:attribute name="id" use="required" type="xs:ID"/>
+      <xs:attribute ref="c:cius-specific" use="optional"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:complexType name="restrictionType">
+    <xs:sequence>
+      <xs:element ref="c:cardinality" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element ref="c:codelist" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element ref="c:value-domain" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element ref="c:semantic-definition" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element ref="c:semantic-datatype" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element ref="c:other" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+
+
+
+
+
   <xs:complexType name="htmlType">
     <xs:complexContent>
       <xs:extension base="c:html-rtf">
@@ -149,7 +182,7 @@
     <xs:attribute name="listURI" type="xs:anyURI" use="optional"/>
     <xs:attribute name="listSchemeURI" type="xs:anyURI" use="optional"/>
   </xs:complexType>
-  
+
   <xs:element name="codelist" type="c:codeListType"/>
 
   <xs:element name="value-domain">
@@ -160,7 +193,7 @@
     </xs:complexType>
   </xs:element>
 
-  <xs:element name="semantic-definition" type="c:htmlType">
+  <xs:element name="semantic-definition">
     <xs:complexType>
       <xs:sequence>
         <xs:element ref="c:term"/>
@@ -241,7 +274,6 @@
       <xs:element ref="c:cardinality"/>
       <xs:element ref="c:syntax-bindings"/>
     </xs:sequence>
-
     <xs:attribute name="id" use="required" type="xs:ID"/>
     <xs:attribute name="level" use="required" type="xs:nonNegativeInteger"/>
     <xs:attribute ref="c:cius-specific" use="required"/>
@@ -252,7 +284,6 @@
       <xs:extension base="c:coreElementType"/>
     </xs:complexContent>
   </xs:complexType>
-
 
   <xs:complexType name="businessTermType">
     <xs:complexContent>
@@ -273,17 +304,6 @@
   <xs:element name="business-group" type="c:businessGroupType" substitutionGroup="c:core-element"/>
 
 
-  <xs:complexType name="restrictionType">
-    <xs:sequence>
-      <xs:element ref="c:cardinality" minOccurs="0" maxOccurs="unbounded"/>
-      <xs:element ref="c:codelist" minOccurs="0" maxOccurs="unbounded"/>
-      <xs:element ref="c:value-domain" minOccurs="0" maxOccurs="unbounded"/>
-      <xs:element ref="c:semantic-definition" minOccurs="0" maxOccurs="unbounded"/>
-      <xs:element ref="c:semantic-datatype" minOccurs="0" maxOccurs="unbounded"/>
-      <xs:element ref="c:other" minOccurs="0" maxOccurs="1"/>
-    </xs:sequence>
-  </xs:complexType>
-
   <xs:element name="information-elements">
     <xs:complexType>
       <xs:sequence maxOccurs="unbounded">
@@ -292,31 +312,7 @@
     </xs:complexType>
   </xs:element>
 
-  <xs:element name="rule">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element ref="c:description" maxOccurs="unbounded"/>
-        <xs:element name="restrictions" type="c:restrictionType" minOccurs="0"/>
-        <xs:element ref="c:schematron" minOccurs="0"/>
-      </xs:sequence>
-      <xs:attribute name="id" use="required" type="xs:ID"/>
-      <!-- information given within the attribute will be given explicitly within the restriction element -->
-      <!-- <xs:attribute name="core-elements" use="optional">-->
-      <!-- <xs:simpleType><xs:list itemType="xs:normalizedString"/></xs:simpleType>-->
-      <!--</xs:attribute>-->
 
-      <xs:attribute ref="c:cius-specific" use="optional"/>
-
-    </xs:complexType>
-  </xs:element>
-
-  <xs:element name="business-rules">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element ref="c:rule" maxOccurs="unbounded"/>
-      </xs:sequence>
-    </xs:complexType>
-  </xs:element>
 
   <!-- Where to define extensions? as type attribute or as on element? -->
   <xs:element name="cius">

--- a/schema/ce-config.xsd
+++ b/schema/ce-config.xsd
@@ -6,7 +6,7 @@
 
   <!-- Import xml: namespace to inlcude xml:lang attribute -->
   <xs:import namespace="http://www.w3.org/XML/1998/namespace"
-    schemaLocation="http://www.w3.org/2001/xml.xsd" />
+    schemaLocation="http://www.w3.org/2001/xml.xsd"/>
 
 
   <xs:group name="any-html">
@@ -81,7 +81,7 @@
    | Global complexType Definitions
    -->
 
-<!-- Inlcude html content but no xml:lang attribute required. Use htmlType if
+  <!-- Inlcude html content but no xml:lang attribute required. Use htmlType if
     xml:lang is requires -->
   <xs:complexType name="html-rtf" mixed="true">
     <xs:group ref="c:any-html" minOccurs="0" maxOccurs="1"/>
@@ -99,7 +99,7 @@
   <xs:complexType name="htmlType">
     <xs:complexContent>
       <xs:extension base="c:html-rtf">
-        <xs:attribute ref="xml:lang" use="required" />
+        <xs:attribute ref="xml:lang" use="required"/>
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
@@ -200,7 +200,7 @@
   <!-- Version of the specification (This should be concat with the technical name equal to business term "Specification identification")-->
   <xs:element name="version" type="xs:normalizedString"/>
   <!-- The status of the specification -->
-  <xs:element name="status" >
+  <xs:element name="status">
     <xs:simpleType>
       <xs:restriction base="xs:normalizedString">
         <xs:enumeration value="planned"/>
@@ -227,6 +227,7 @@
   <!-- A hyperlink to more detailed information about the specification. Preferably that should include contact information. -->
   <xs:element name="furtherInformation" type="xs:anyURI"/>
 
+  <!-- Metadata section describing with general infomation about the CIUS  -->
   <xs:element name="metadata">
     <xs:complexType>
       <xs:sequence>
@@ -239,8 +240,8 @@
         <xs:element ref="c:date"/>
         <xs:element ref="c:publisher"/>
         <xs:element ref="c:governor"/>
-        <xs:element minOccurs="0" ref="c:country"/>
-        <xs:element minOccurs="0" ref="c:sector"/>
+        <xs:element ref="c:country" minOccurs="0"/>
+        <xs:element ref="c:sector" minOccurs="0"/>
         <xs:element ref="c:contact"/>
         <xs:element ref="c:abstract"/>
         <xs:element ref="c:furtherInformation"/>
@@ -253,6 +254,7 @@
   <xs:element name="description" type="c:htmlType"/>
   <xs:element name="term"/>
 
+  <!--  -->
   <xs:element name="cardinality">
     <xs:complexType>
       <xs:sequence>

--- a/schema/ce-config.xsd
+++ b/schema/ce-config.xsd
@@ -4,6 +4,11 @@
   targetNamespace="urn:x-namespace:yet:to:be:determined"
   xmlns:c="urn:x-namespace:yet:to:be:determined">
 
+  <!-- Import xml: namespace to inlcude xml:lang attribute -->
+  <xs:import namespace="http://www.w3.org/XML/1998/namespace"
+    schemaLocation="http://www.w3.org/2001/xml.xsd" />
+
+
   <xs:group name="any-html">
     <xs:sequence>
       <xs:any namespace="http://www.w3.org/1999/xhtml" processContents="skip"/>
@@ -55,7 +60,8 @@
   <!-- Natural language of xml text content -->
   <!-- According to
     https://www.w3.org/International/questions/qa-when-xmllang.en
-    it is NOT recommended to use xml:lang for natural language content of elements -->
+    it is NOT recommended to use xml:lang for natural language content of
+    external elements -->
   <xs:attribute name="language" type="xs:normalizedString"/>
 
   <!-- Indicates wheter an element is CIUS specific. -->
@@ -90,7 +96,7 @@
   <xs:complexType name="htmlType">
     <xs:complexContent>
       <xs:extension base="c:html-rtf">
-        <xs:attribute ref="c:language"/>
+        <xs:attribute ref="xml:lang" use="required" />
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>

--- a/schema/ce-config.xsd
+++ b/schema/ce-config.xsd
@@ -1,27 +1,68 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  elementFormDefault="qualified"
   targetNamespace="urn:x-namespace:yet:to:be:determined"
   xmlns:c="urn:x-namespace:yet:to:be:determined">
 
+
+  <!-- 
+   | Global simpleType Definitions
+   -->
+  
+  <!-- All semantic datatypes as defined by CEN except String type -->
+  <xs:simpleType name="restrictedSemanticDataTypeType">
+    <xs:restriction base="xs:normalizedString">
+      <xs:enumeration value="Binary"/>
+      <xs:enumeration value="Date"/>
+      <xs:enumeration value="Decimal"/>
+      <xs:enumeration value="Amount"/>
+      <xs:enumeration value="Unit price amount"/>
+      <xs:enumeration value="Quantity"/>
+      <xs:enumeration value="Percentage"/>
+      <xs:enumeration value="Identifier"/>
+      <xs:enumeration value="Document reference"/>
+      <xs:enumeration value="Code"/>
+      <xs:enumeration value="Text"/>
+      <xs:enumeration value="Binary object"/>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <!-- String semantic datatype as defined by CEN -->
+  <xs:simpleType name="semanticStringTypeType">
+    <xs:restriction base="xs:normalizedString">
+      <xs:enumeration value="String"/>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <!-- All semantic datatypes as defined by CEN -->
+  <xs:simpleType name="semanticDataTypeType">
+    <xs:union
+      memberTypes="c:restrictedSemanticDataTypeType c:semanticStringTypeType"/>
+  </xs:simpleType>
+  
+  <!-- 
+   | Global Attribute Definitions
+   -->
+
   <!-- Natural language of xml text content -->
   <xs:attribute name="language" type="xs:normalizedString"/>
+
+  <!-- Indicates wheter an element is CIUS specific -->
   <xs:attribute name="cius-specific" type="xs:boolean"/>
 
-  <xs:complexType name="html-rtf" mixed="true">
-    <xs:group ref="c:any-html" minOccurs="0" maxOccurs="1"/>
-  </xs:complexType>
-
-
-  <xs:group name="any-html">
-    <xs:sequence>
-      <xs:any namespace="http://www.w3.org/1999/xhtml" processContents="skip"/>
-    </xs:sequence>
-  </xs:group>
-
-
+  <!-- 
   <xs:attributeGroup name="any-attribute">
     <xs:anyAttribute processContents="skip"/>
   </xs:attributeGroup>
+   -->
+
+  <!-- 
+   | Global complexType Definitions
+   -->
+  
+  <xs:complexType name="html-rtf" mixed="true">
+    <xs:group ref="c:any-html" minOccurs="0" maxOccurs="1"/>
+  </xs:complexType>
 
   <xs:complexType name="any">
     <xs:sequence maxOccurs="unbounded">
@@ -29,30 +70,100 @@
     </xs:sequence>
   </xs:complexType>
 
+  <!-- According to https://www.w3.org/International/questions/qa-when-xmllang it is NOT recommended to use xml>lang for natural language content of elements -->
+  <xs:complexType name="htmlType">
+    <xs:complexContent>
+      <xs:extension base="c:html-rtf">
+        <xs:attribute ref="c:language"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  
 
+  <xs:group name="any-html">
+    <xs:sequence>
+      <xs:any namespace="http://www.w3.org/1999/xhtml" processContents="skip"/>
+    </xs:sequence>
+  </xs:group>
+  
+  <xs:complexType name="codeListType">
+    <xs:sequence>
+      <!-- white listing subset of CEN codelist codes -->
+      <xs:element name="allowed-codes" type="xs:token"/>
+    </xs:sequence>
+    
+    <!-- Shamelessly adopted and adapted from UBL 2.1 -->
+    <xs:attribute name="listAgencyID" type="xs:normalizedString" use="optional"/>
+    
+    <xs:attribute name="listAgencyName" type="xs:string" use="optional"/>
+    
+    <xs:attribute name="listName" type="xs:string" use="optional"/>
+    
+    <xs:attribute name="listVersionID" type="xs:normalizedString" use="optional"/>
+    
+    <xs:attribute name="name" type="xs:string" use="optional"/>
+    
+    <xs:attribute ref="c:language" use="optional"/>
+    
+    <xs:attribute name="listURI" type="xs:anyURI" use="optional"/>
+    
+    <xs:attribute name="listSchemeURI" type="xs:anyURI" use="optional"/>
+    
+  </xs:complexType>
+  
+  <xs:complexType name="restrictionType">
+    <xs:sequence>
+      <xs:element ref="c:cardinality" minOccurs="0"/>
+      <xs:element ref="c:codelist" minOccurs="0"/>
+      <xs:element ref="c:value-domain" minOccurs="0"/>
+      <xs:element ref="c:semantic-definition" minOccurs="0"/>
+      <xs:element ref="c:semantic-datatype" minOccurs="0"/>
+      <xs:element ref="c:other" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
 
-
-  <xs:element name="metadata">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element ref="c:nameShort"/>
-        <xs:element ref="c:nameLong"/>
-        <xs:element ref="c:nameTechnical"/>
-        <xs:element ref="c:version"/>
-        <xs:element ref="c:status"/>
-        <xs:element ref="c:date"/>
-        <xs:element ref="c:publisher"/>
-        <xs:element ref="c:governor"/>
-        <xs:element minOccurs="0" ref="c:country"/>
-        <xs:element minOccurs="0" ref="c:sector"/>
-        <xs:element ref="c:email"/>
-        <xs:element ref="c:abstract"/>
-      </xs:sequence>
-    </xs:complexType>
-  </xs:element>
-
+  <!-- General abstract XML type with common elements and attributes for Business Terms and Business Rules -->
+  <xs:complexType name="coreElementType" abstract="true">
+    <xs:sequence>
+      <xs:element ref="c:definition"/>
+      <xs:element ref="c:cardinality"/>
+      <xs:element ref="c:syntax-bindings"/>
+    </xs:sequence>
+    
+    <xs:attribute name="id" use="required" type="xs:ID"/>
+    <xs:attribute name="level" use="required" type="xs:nonNegativeInteger"/>
+    <xs:attribute ref="c:cius-specific" use="required"/>
+  </xs:complexType>
+  
+  <xs:complexType name="businessGroupType">
+    <xs:complexContent>
+      <xs:extension base="c:coreElementType"/>
+    </xs:complexContent>
+  </xs:complexType>
+  
+  
+  <xs:complexType name="businessTermType">
+    <xs:complexContent>
+      <xs:extension base="c:coreElementType">
+        <xs:sequence>
+          <xs:element ref="c:usage-note" maxOccurs="1"/>
+        </xs:sequence>
+        <!-- This can be enhanced to contain simpleType and rules on the ids -->
+        <xs:attribute name="business-group" use="optional" type="xs:IDREF"/>
+        
+        <xs:attribute name="semantic-datatype" use="required"
+          type="c:semanticDataTypeType"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  
+  
+  <!-- 
+   | Global Element Definitions
+   -->
+  
   <!-- renzo: change most to normalized string then users do not need to implement own whitespace normalization -->
-
+  
   <!-- A short descriptive name based on a common semantic -->
   <xs:element name="nameShort" type="xs:normalizedString"/>
   
@@ -85,18 +196,30 @@
   
   <!-- A brief description of what the specification is intended for.-->
   <xs:element name="abstract" type="c:html-rtf"/>
-
+  
   <!-- The development, production status of the CIUS or Extension-->
   <xs:element name="status" type="xs:normalizedString"/>
+  
+  
+  <xs:element name="metadata">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="c:nameShort"/>
+        <xs:element ref="c:nameLong"/>
+        <xs:element ref="c:nameTechnical"/>
+        <xs:element ref="c:version"/>
+        <xs:element ref="c:status"/>
+        <xs:element ref="c:date"/>
+        <xs:element ref="c:publisher"/>
+        <xs:element ref="c:governor"/>
+        <xs:element minOccurs="0" ref="c:country"/>
+        <xs:element minOccurs="0" ref="c:sector"/>
+        <xs:element ref="c:email"/>
+        <xs:element ref="c:abstract"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
 
-  <!-- According to https://www.w3.org/International/questions/qa-when-xmllang it is NOT recommended to use xml>lang for natural language content of elements -->
-  <xs:complexType name="htmlType">
-    <xs:complexContent>
-      <xs:extension base="c:html-rtf">
-        <xs:attribute ref="c:language"/>
-      </xs:extension>
-    </xs:complexContent>
-  </xs:complexType>
 
   <xs:element name="definition" type="c:htmlType"/>
   <xs:element name="description" type="c:htmlType"/>
@@ -125,31 +248,7 @@
     <xs:complexType/>
   </xs:element>
 
-  <xs:complexType name="codeListType">
-    <xs:sequence>
-      <!-- white listing subset of CEN codelist -->
-      <xs:element name="allowed-codes" type="xs:token"/>
-    </xs:sequence>
-
-    <!-- Shamelessly adopted and adpted from UBL 2.1 -->
-    <xs:attribute name="listAgencyID" type="xs:normalizedString" use="optional"/>
-
-    <xs:attribute name="listAgencyName" type="xs:string" use="optional"/>
-
-    <xs:attribute name="listName" type="xs:string" use="optional"/>
-
-    <xs:attribute name="listVersionID" type="xs:normalizedString" use="optional"/>
-
-    <xs:attribute name="name" type="xs:string" use="optional"/>
-
-    <xs:attribute ref="c:language" use="optional"/>
-
-    <xs:attribute name="listURI" type="xs:anyURI" use="optional"/>
-
-    <xs:attribute name="listSchemeURI" type="xs:anyURI" use="optional"/>
-
-  </xs:complexType>
-
+  
   <xs:element name="codelist" type="c:codeListType"/>
 
   <xs:element name="value-domain">
@@ -193,90 +292,26 @@
   <xs:element name="schematron">
     <xs:complexType>
       <xs:sequence>
-        <xs:any namespace="http://purl.oclc.org/dsdl/schematron" processContents="lax"/>
+        <xs:any namespace="http://purl.oclc.org/dsdl/schematron"
+          processContents="lax"/>
       </xs:sequence>
     </xs:complexType>
   </xs:element>
 
-
-  <xs:simpleType name="restrictedSemanticDataTypeType">
-    <xs:restriction base="xs:normalizedString">
-      <xs:enumeration value="Binary"/>
-      <xs:enumeration value="Date"/>
-      <xs:enumeration value="Decimal"/>
-      <xs:enumeration value="Amount"/>
-      <xs:enumeration value="Unit price amount"/>
-      <xs:enumeration value="Quantity"/>
-      <xs:enumeration value="Percentage"/>
-      <xs:enumeration value="Identifier"/>
-      <xs:enumeration value="Document reference"/>
-      <xs:enumeration value="Code"/>
-      <xs:enumeration value="Text"/>
-      <xs:enumeration value="Binary object"/>
-    </xs:restriction>
-  </xs:simpleType>
-
-  <xs:simpleType name="semanticStringTypeType">
-    <xs:restriction base="xs:normalizedString">
-      <xs:enumeration value="String"/>
-    </xs:restriction>
-  </xs:simpleType>
-
-  <xs:simpleType name="semanticDataTypeType">
-    <xs:union memberTypes="c:restrictedSemanticDataTypeType c:semanticStringTypeType"/>
-  </xs:simpleType>
-
   <xs:element name="semantic-datatype" type="c:restrictedSemanticDataTypeType"/>
 
 
-  <xs:complexType name="coreElementType" abstract="true">
-    <xs:sequence>
-      <xs:element ref="c:definition"/>
-      <xs:element ref="c:cardinality"/>
-      <xs:element ref="c:syntax-bindings"/>
-    </xs:sequence>
 
-    <xs:attribute name="id" use="required" type="xs:ID"/>
-    <xs:attribute name="level" use="required" type="xs:nonNegativeInteger"/>
-    <xs:attribute ref="c:cius-specific" use="required"/>
-  </xs:complexType>
-
-  <xs:complexType name="businessGroupType">
-    <xs:complexContent>
-      <xs:extension base="c:coreElementType"/>
-    </xs:complexContent>
-  </xs:complexType>
-
-
-  <xs:complexType name="businessTermType">
-    <xs:complexContent>
-      <xs:extension base="c:coreElementType">
-        <xs:sequence>
-          <xs:element ref="c:usage-note" maxOccurs="1"/>
-        </xs:sequence>
-        <!-- This can be enhanced to contain simpleType and rules on the ids -->
-        <xs:attribute name="business-group" use="optional" type="xs:IDREF"/>
-        
-        <xs:attribute name="semantic-datatype" use="required" type="c:semanticDataTypeType"/>
-      </xs:extension>
-    </xs:complexContent>
-  </xs:complexType>
-
+  <!-- Basis for substitution group  -->
   <xs:element name="core-element" type="c:coreElementType" abstract="true"/>
-  <xs:element name="business-term" type="c:businessTermType" substitutionGroup="c:core-element"/>
-  <xs:element name="business-group" type="c:businessGroupType" substitutionGroup="c:core-element"/>
+
+  <xs:element name="business-term" type="c:businessTermType"
+    substitutionGroup="c:core-element"/>
+
+  <xs:element name="business-group" type="c:businessGroupType"
+    substitutionGroup="c:core-element"/>
 
 
-  <xs:complexType name="restrictionType">
-    <xs:sequence>
-      <xs:element ref="c:cardinality" minOccurs="0"/>
-      <xs:element ref="c:codelist" minOccurs="0"/>
-      <xs:element ref="c:value-domain" minOccurs="0"/>
-      <xs:element ref="c:semantic-definition" minOccurs="0"/>
-      <xs:element ref="c:semantic-datatype" minOccurs="0"/>
-      <xs:element ref="c:other" minOccurs="0"/>
-    </xs:sequence>
-  </xs:complexType>
 
   <xs:element name="information-elements">
     <xs:complexType>
@@ -286,24 +321,32 @@
     </xs:complexType>
   </xs:element>
 
+  <!-- A business rule description -->
   <xs:element name="rule">
     <xs:complexType>
       <xs:sequence>
+        <!-- Natural language description of Business Rule-->
         <xs:element ref="c:description" maxOccurs="unbounded"/>
-        <xs:element name="restrictions" type="c:restrictionType" minOccurs="0"/>
+        <!-- One or many restrictions defined by this rule -->
+        <xs:element name="restriction" type="c:restrictionType" minOccurs="0"
+          maxOccurs="unbounded"/>
+        <!-- A schematron rule implementing the Business Rule -->
         <xs:element ref="c:schematron" minOccurs="0"/>
       </xs:sequence>
+
       <xs:attribute name="id" use="required" type="xs:ID"/>
       <xs:attribute name="core-elements" use="optional">
         <xs:simpleType>
-          <xs:list itemType="xs:normalizedString"></xs:list>
+          <xs:list itemType="xs:normalizedString"/>
         </xs:simpleType>
       </xs:attribute>
+      <!-- If it is a CIUS specific restriction -->
       <xs:attribute ref="c:cius-specific" use="optional"/>
 
     </xs:complexType>
   </xs:element>
 
+  <!-- The set of busines rules  (either all or the rules with CIUS specific restrictions) -->
   <xs:element name="business-rules">
     <xs:complexType>
       <xs:sequence>
@@ -312,18 +355,19 @@
     </xs:complexType>
   </xs:element>
 
-  <!-- Where to define extensions? as type attribute or as on element? -->
+  <!-- The root element of a CIUS description -->
   <xs:element name="cius">
     <xs:complexType>
       <xs:sequence>
         <xs:element ref="c:metadata"/>
-        <!-- maybe to redundant to the abstract elem within metadata -->
+        <!-- maybe redundant to the abstract elem within metadata -->
         <xs:element ref="c:description"/>
         <xs:element ref="c:information-elements" minOccurs="0"/>
         <xs:element ref="c:business-rules"/>
       </xs:sequence>
       <!-- CIUS (TRUE) or Extension (FALSE)-->
-      <!-- renzo: I would not use a bollean for extensibibilty eitehr enum or token -->
+      <!-- renzo: I would not use a boolean for extensibibilty either a enum or token. -->
+      <!-- Maybe best is to make an own extension element -->
       <xs:attribute name="type" use="required" type="xs:boolean"/>
 
     </xs:complexType>

--- a/schema/ce-config.xsd
+++ b/schema/ce-config.xsd
@@ -182,6 +182,34 @@
     </xs:complexContent>
   </xs:complexType>
 
+  <!-- Type of the root element cius and base for the restriction of
+    extensionType -->
+  <xs:complexType name="ciusType">
+    <xs:sequence>
+      <xs:element ref="c:metadata"/>
+      <!-- maybe redundant to the abstract elem within metadata -->
+      <xs:element ref="c:description"/>
+      <xs:element ref="c:information-elements" minOccurs="0"/>
+      <xs:element ref="c:business-rules"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <!-- Type of the root element extension a restriction of
+    ciusType -->
+  <xs:complexType name="extensionType">
+    <xs:complexContent>
+      <xs:restriction base="c:ciusType">
+        <xs:sequence>
+          <xs:element ref="c:metadata"/>
+          <!-- maybe redundant to the abstract elem within metadata -->
+          <xs:element ref="c:description"/>
+          <xs:element ref="c:information-elements"/>
+          <xs:element ref="c:business-rules"/>
+        </xs:sequence>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+
 
   <!-- 
    | Global Element Definitions
@@ -399,23 +427,14 @@
     </xs:complexType>
   </xs:element>
 
+
+
   <!-- The root element of a CIUS description -->
   <!-- See EN 16931-1:2017 chapter 7 -->
-  <xs:element name="cius">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element ref="c:metadata"/>
-        <!-- maybe redundant to the abstract elem within metadata -->
-        <xs:element ref="c:description"/>
-        <xs:element ref="c:information-elements" minOccurs="0"/>
-        <xs:element ref="c:business-rules"/>
-      </xs:sequence>
-      <!-- CIUS (TRUE) or Extension (FALSE)-->
-      <!-- renzo: I would not use a boolean for extensibibilty either a enum or token. -->
-      <!-- Maybe best is to make an own extension element -->
-      <xs:attribute name="type" use="required" type="xs:boolean"/>
+  <xs:element name="cius" type="c:ciusType"/>
 
-    </xs:complexType>
-  </xs:element>
+  <xs:element name="extension" type="c:extensionType"> </xs:element>
+
+
 
 </xs:schema>

--- a/schema/ce-config.xsd
+++ b/schema/ce-config.xsd
@@ -61,7 +61,7 @@
   <!-- According to
     https://www.w3.org/International/questions/qa-when-xmllang.en
     it is NOT recommended to use xml:lang for natural language content of
-    external elements -->
+    external elements. Hence definition of own language attribute. -->
   <xs:attribute name="language" type="xs:normalizedString"/>
 
   <!-- Indicates wheter an element is CIUS specific. -->
@@ -81,6 +81,8 @@
    | Global complexType Definitions
    -->
 
+<!-- Inlcude html content but no xml:lang attribute required. Use htmlType if
+    xml:lang is requires -->
   <xs:complexType name="html-rtf" mixed="true">
     <xs:group ref="c:any-html" minOccurs="0" maxOccurs="1"/>
   </xs:complexType>
@@ -92,7 +94,8 @@
     </xs:sequence>
   </xs:complexType>
 
-  <!-- According to https://www.w3.org/International/questions/qa-when-xmllang it is NOT recommended to use xml>lang for natural language content of elements -->
+  <!-- According to
+    https://www.w3.org/International/questions/qa-when-xmllang.en it is recommended to use xml:lang for natural language content of elements -->
   <xs:complexType name="htmlType">
     <xs:complexContent>
       <xs:extension base="c:html-rtf">
@@ -220,7 +223,7 @@
   <!-- e-Mail contact to publisher.-->
   <xs:element name="contact" type="xs:normalizedString"/>
   <!-- A brief description of what the specification is intended for.-->
-  <xs:element name="abstract" type="c:html-rtf"/>
+  <xs:element name="abstract" type="c:htmlType"/>
   <!-- A hyperlink to more detailed information about the specification. Preferably that should include contact information. -->
   <xs:element name="furtherInformation" type="xs:anyURI"/>
 

--- a/schema/ce-config.xsd
+++ b/schema/ce-config.xsd
@@ -53,23 +53,6 @@
       memberTypes="c:restrictedSemanticDataTypeType c:semanticStringTypeType"/>
   </xs:simpleType>
 
-  <!-- 
-   | Global Attribute Definitions
-   -->
-
-  <!-- Natural language of xml text content -->
-  <!-- According to
-    https://www.w3.org/International/questions/qa-when-xmllang.en
-    it is NOT recommended to use xml:lang for natural language content of
-    external elements. Hence definition of own language attribute. -->
-  <xs:attribute name="language" type="xs:normalizedString"/>
-
-  <!-- Indicates wheter an element is CIUS specific. -->
-  <!-- It is a qualitativ
-    indicator although this might also be automatically deduced from comparisons
-    to main EN specification
-  -->
-  <xs:attribute name="cius-specific" type="xs:boolean"/>
 
   <!-- 
   <xs:attributeGroup name="any-attribute">
@@ -122,7 +105,12 @@
     <!-- Shamelessly adopted and adapted from UBL 2.1 -->
     <xs:attribute name="name" type="xs:string" use="optional"/>
     <!-- Main language of external codelist -->
-    <xs:attribute ref="c:language" use="optional"/>
+    <!-- Natural language of xml text content -->
+    <!-- According to
+    https://www.w3.org/International/questions/qa-when-xmllang.en
+    it is NOT recommended to use xml:lang for natural language content of
+    external elements. Hence definition of own language attribute. -->
+    <xs:attribute name="language" type="xs:normalizedString" use="optional"/>
     <!-- Shamelessly adopted and adapted from UBL 2.1 -->
     <xs:attribute name="listURI" type="xs:anyURI" use="optional"/>
     <!-- Shamelessly adopted and adapted from UBL 2.1 -->
@@ -155,7 +143,7 @@
     <!-- The nesting level within Business Groups -->
     <xs:attribute name="level" use="required" type="xs:nonNegativeInteger"/>
     <!-- Does it contian CIUS specific restrictions? -->
-    <xs:attribute ref="c:cius-specific" use="required"/>
+    <xs:attribute name="cius-specific" type="xs:boolean" use="required"/>
   </xs:complexType>
 
   <!-- The Business Group type -->
@@ -413,7 +401,7 @@
         </xs:simpleType>
       </xs:attribute>
       <!-- If it is a CIUS specific restriction -->
-      <xs:attribute ref="c:cius-specific" use="optional"/>
+      <xs:attribute name="cius-specific" type="xs:boolean" use="required"/>
 
     </xs:complexType>
   </xs:element>

--- a/schema/xml.xsd
+++ b/schema/xml.xsd
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://www.w3.org/XML/1998/namespace" xmlns:c="urn:x-namespace:yet:to:be:determined">
+  <xs:import namespace="urn:x-namespace:yet:to:be:determined" schemaLocation="ce-config.xsd"/>
+  <xs:attribute name="lang"/>
+</xs:schema>

--- a/schema/xml.xsd
+++ b/schema/xml.xsd
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://www.w3.org/XML/1998/namespace" xmlns:c="urn:x-namespace:yet:to:be:determined">
-  <xs:import namespace="urn:x-namespace:yet:to:be:determined" schemaLocation="ce-config.xsd"/>
-  <xs:attribute name="lang"/>
-</xs:schema>


### PR DESCRIPTION
Hi,

This is the status based on our discussion of 2018-10-25.

What this merge includes from the discussion:
- (re-)added an atrribute named "type" to indicate if it is a CIUS for restriction or for extension
- deleted cius-specific attribute in rules element

It does **not yet** include agreed changes we discussed and agreed upon:
- all references from rules to terms should be in own `<term>` element of each restriction and be 1 to many. And not as list of ids in an attribute. 
- all element and attribute names in a consistent naming scheme e.g. all in CamelCase. Currently it is a mix of CamelCase and dash separated naming


